### PR TITLE
Don't trim comments

### DIFF
--- a/src/LuauRenderer/nodes/statements/renderComment.ts
+++ b/src/LuauRenderer/nodes/statements/renderComment.ts
@@ -7,9 +7,7 @@ export function renderComment(state: RenderState, node: luau.Comment) {
 	if (lines.length > 1) {
 		const eqStr = getSafeBracketEquals(node.text);
 		let result = state.line(`--[${eqStr}[`);
-		result += state.block(() =>
-			lines.map(line => state.line(line)).join(""),
-		);
+		result += state.block(() => lines.map(line => state.line(line)).join(""));
 		result += state.line(`]${eqStr}]`);
 		return result;
 	} else {

--- a/src/LuauRenderer/nodes/statements/renderComment.ts
+++ b/src/LuauRenderer/nodes/statements/renderComment.ts
@@ -8,15 +8,11 @@ export function renderComment(state: RenderState, node: luau.Comment) {
 		const eqStr = getSafeBracketEquals(node.text);
 		let result = state.line(`--[${eqStr}[`);
 		result += state.block(() =>
-			lines
-				.map(line => line.trim())
-				.filter(trimmed => trimmed !== "")
-				.map(line => state.line(line))
-				.join(""),
+			lines.map(line => state.line(line)).join(""),
 		);
 		result += state.line(`]${eqStr}]`);
 		return result;
 	} else {
-		return lines.map(line => state.line(`-- ${line.trim()}`)).join("");
+		return lines.map(line => state.line(`--${line}`)).join("");
 	}
 }


### PR DESCRIPTION
Trimming comment whitespace doesn't really make sense. We should avoid modifying user input unnecessarily.

Current drawbacks:
- It prevents Luau instruction comments, like `--!optimize 2`, from being written in TS directly. It's impossible to add them to roblox-ts code without manual post-processing of the emit.
- Removing double newlines hurts readability of documentation comments; The writer will have inserted them for a reason.
- Width formatting is removed, like for tables that start at lower columns in lower rows:
```ts
// abcdef
//     ef
```