### PR TITLE
Fix isReservedIdentifier

### DIFF
--- a/src/LuauAST/util/isReservedIdentifier.ts
+++ b/src/LuauAST/util/isReservedIdentifier.ts
@@ -1,5 +1,5 @@
 import { globals } from "LuauAST/impl/globals";
 
 export function isReservedIdentifier(id: string) {
-	return id in globals;
+	return globals.hasOwnProperty(id);
 }

--- a/src/LuauAST/util/isReservedIdentifier.ts
+++ b/src/LuauAST/util/isReservedIdentifier.ts
@@ -1,5 +1,5 @@
 import { globals } from "LuauAST/impl/globals";
 
 export function isReservedIdentifier(id: string) {
-	return globals.hasOwnProperty(id);
+	return Object.prototype.hasOwnProperty.call(globals, id);
 }


### PR DESCRIPTION
Switches `isReservedIdentifier` to use `hasOwnProperty` to avoid matching the Object prototype.