### PR TITLE
Use `luau.SyntaxKind.MixedTable` where necessary

### DIFF
--- a/src/LuauAST/impl/enums.ts
+++ b/src/LuauAST/impl/enums.ts
@@ -49,7 +49,7 @@ export enum SyntaxKind {
 	FirstIndexableExpression = Identifier,
 	LastIndexableExpression = ParenthesizedExpression,
 	FirstExpression = Identifier,
-	LastExpression = Set,
+	LastExpression = MixedTable,
 	FirstStatement = Assignment,
 	LastStatement = Comment,
 	FirstField = MapField,

--- a/src/LuauAST/impl/typeGuards.ts
+++ b/src/LuauAST/impl/typeGuards.ts
@@ -102,7 +102,12 @@ export const isSimplePrimitive = makeGuard(
 	luau.SyntaxKind.StringLiteral,
 );
 
-export const isTable = makeGuard(luau.SyntaxKind.Array, luau.SyntaxKind.Set, luau.SyntaxKind.Map);
+export const isTable = makeGuard(
+	luau.SyntaxKind.Array,
+	luau.SyntaxKind.Set,
+	luau.SyntaxKind.Map,
+	luau.SyntaxKind.MixedTable,
+);
 
 export const isFinalStatement = makeGuard(
 	luau.SyntaxKind.BreakStatement,


### PR DESCRIPTION
`LastExpression` enum member currently points to `Set` while `MixedTable` holds the actual last expression position number.