### PR TITLE
Remove inner parenthesis wrapping from unary expression rendering

### DIFF
--- a/src/LuauRenderer/nodes/expressions/renderUnaryExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderUnaryExpression.ts
@@ -2,15 +2,6 @@ import luau from "LuauAST";
 import { render, RenderState } from "LuauRenderer";
 import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
-function needsInnerParentheses(node: luau.UnaryExpression) {
-	// #{} and -{} are invalid
-	if ((node.operator === "#" || node.operator === "-") && luau.isTable(node.expression)) {
-		return true;
-	}
-
-	return false;
-}
-
 function needsSpace(node: luau.UnaryExpression) {
 	// not always needs a space
 	if (node.operator === "not") {
@@ -27,19 +18,12 @@ function needsSpace(node: luau.UnaryExpression) {
 }
 
 export function renderUnaryExpression(state: RenderState, node: luau.UnaryExpression) {
-	let expStr = render(state, node.expression);
 	let opStr = node.operator;
-
 	if (needsSpace(node)) {
 		opStr += " ";
 	}
 
-	if (needsInnerParentheses(node)) {
-		expStr = `(${expStr})`;
-	}
-
-	let result = `${opStr}${expStr}`;
-
+	let result = `${opStr}${render(state, node.expression)}`;
 	if (needsParentheses(node)) {
 		result = `(${result})`;
 	}


### PR DESCRIPTION
At some point, `#{}` and `-{}` became valid in luau, making it unnecessary to wrap tables in parenthesis.