### PR TITLE
Fix interpolated string rendering issues

### DIFF
--- a/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
+++ b/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
@@ -3,10 +3,14 @@ import { RenderState } from "LuauRenderer";
 
 export function renderInterpolatedStringPart(state: RenderState, node: luau.InterpolatedStringPart) {
 	// escape braces and newlines, but do not touch braces within unicode escape codes
-	return node.text
-		.replace(
-			/(\\u\{[0-9A-Fa-f]+\})|([{}])/g,
-			(_, unicodeEscape: string | undefined, brace: string | undefined) => unicodeEscape ?? "\\" + brace,
-		)
-		.replace(/(\r\n?|\n)/g, "\\$1");
+	return (
+		node.text
+			.replace(
+				/(\\u{[0-9A-Fa-f]+})|([{}])/g,
+				(_, unicodeEscape: string | undefined, brace: string | undefined) => unicodeEscape ?? "\\" + brace,
+			)
+			// captures a CR with optionally an LF after it
+			// or just an LF on its own
+			.replace(/(\r\n?|\n)/g, "\\$1")
+	);
 }

--- a/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
+++ b/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
@@ -2,8 +2,11 @@ import luau from "LuauAST";
 import { RenderState } from "LuauRenderer";
 
 export function renderInterpolatedStringPart(state: RenderState, node: luau.InterpolatedStringPart) {
-	// braces and newlines are escaped to be valid in luau
-	// () captures result, [] to search for any of: {}
-	// $1 fills in capture from original search
-	return node.text.replace(/([{}])/g, "\\$1").replace(/(\r\n?|\n)/g, "\\$1");
+	// escape braces and newlines, but do not touch braces within unicode escape codes
+	return node.text
+		.replace(
+			/(\\u\{[0-9A-Fa-f]+\})|([{}])/g,
+			(_, unicodeEscape: string | undefined, brace: string | undefined) => unicodeEscape ?? "\\" + brace,
+		)
+		.replace(/(\r\n?|\n)/g, "\\$1");
 }

--- a/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
+++ b/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
@@ -5,5 +5,5 @@ export function renderInterpolatedStringPart(state: RenderState, node: luau.Inte
 	// braces and newlines are escaped to be valid in luau
 	// () captures result, [] to search for any of: {}
 	// $1 fills in capture from original search
-	return node.text.replace(/([{}])/g, "\\$1").replace(/\n/g, "\\\n");
+	return node.text.replace(/([{}])/g, "\\$1").replace(/(\r\n?|\n)/g, "\\$1");
 }

--- a/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
+++ b/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
@@ -2,15 +2,11 @@ import luau from "LuauAST";
 import { RenderState } from "LuauRenderer";
 
 export function renderInterpolatedStringPart(state: RenderState, node: luau.InterpolatedStringPart) {
-	// escape braces and newlines, but do not touch braces within unicode escape codes
 	return (
 		node.text
-			.replace(
-				/(\\u{[0-9A-Fa-f]+})|([{}])/g,
-				(_, unicodeEscape: string | undefined, brace: string | undefined) => unicodeEscape ?? "\\" + brace,
-			)
-			// captures a CR with optionally an LF after it
-			// or just an LF on its own
+			// escape braces, but do not touch braces within unicode escape codes
+			.replace(/(\\u{[a-fA-F0-9]+})|([{}])/g, (_, unicodeEscape, brace) => unicodeEscape ?? "\\" + brace)
+			// escape newlines, captures a CR with optionally an LF after it or just an LF on its own
 			.replace(/(\r\n?|\n)/g, "\\$1")
 	);
 }


### PR DESCRIPTION
Fixes #458 and #484

## #458: Incorrect escaping for multi-line interpolated string literals

The issue was that the escape logic did not pick up Windows-style line endings properly. For this we need to also check for `\r` followed by an optional `\n`.

### Input
```ts
warn(`look I am
a multiline string`)
```

### Before
```luau
warn(`look I am
\
a multiline string`)
```

### After
```luau
warn(`look I am\
a multiline string`)
```

## #484: Incorrect escaping for unicode escape sequences in interpolated string literals

### Input
```ts
const string_a = "\u{E000}";
const string_b = `\u{E000}`;
```

### Before
```luau
local string_a = "\u{E000}"
local string_b = `\u\{E000\}`
```

### After
```luau
local string_a = "\u{E000}"
local string_b = `\u{E000}`
```