### PR TITLE
Fix invalid emit of escaped new line character in template and literal strings

### DIFF
--- a/src/LuauRenderer/nodes/expressions/renderStringLiteral.ts
+++ b/src/LuauRenderer/nodes/expressions/renderStringLiteral.ts
@@ -1,6 +1,7 @@
 import luau from "LuauAST";
 import { RenderState } from "LuauRenderer";
 import { getSafeBracketEquals } from "LuauRenderer/util/getSafeBracketEquals";
+import { stripBackslashInEscapedNewLines } from "LuauRenderer/util/stripBackslashInEscapedNewLines";
 
 function needsBracketSpacing(node: luau.StringLiteral) {
 	const parent = node.parent;
@@ -32,6 +33,7 @@ export function renderStringLiteral(state: RenderState, node: luau.StringLiteral
 	} else {
 		const eqStr = getSafeBracketEquals(node.value);
 		const spacing = needsBracketSpacing(node) ? " " : "";
-		return `${spacing}[${eqStr}[${node.value}]${eqStr}]${spacing}`;
+		const value = stripBackslashInEscapedNewLines(node.value);
+		return `${spacing}[${eqStr}[${value}]${eqStr}]${spacing}`;
 	}
 }

--- a/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
+++ b/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
@@ -1,9 +1,10 @@
 import luau from "LuauAST";
 import { RenderState } from "LuauRenderer";
+import { stripBackslashInEscapedNewLines } from "LuauRenderer/util/stripBackslashInEscapedNewLines";
 
 export function renderInterpolatedStringPart(state: RenderState, node: luau.InterpolatedStringPart) {
 	return (
-		node.text
+		stripBackslashInEscapedNewLines(node.text)
 			// escape braces, but do not touch braces within unicode escape codes
 			.replace(/(\\u{[a-fA-F0-9]+})|([{}])/g, (_, unicodeEscape, brace) => unicodeEscape ?? "\\" + brace)
 			// escape newlines, captures a CR with optionally an LF after it or just an LF on its own

--- a/src/LuauRenderer/util/stripBackslashInEscapedNewLines.ts
+++ b/src/LuauRenderer/util/stripBackslashInEscapedNewLines.ts
@@ -1,0 +1,18 @@
+/**
+ * Strips off any excess backslash if it is escaped with `\n`
+ *
+ * **From**:
+ * ```ts
+ * "Hello\
+ * World!"
+ * ```
+ *
+ * **To**:
+ * ```lua
+ * [[Hello
+ * World!]]
+ * ```
+ */
+export function stripBackslashInEscapedNewLines(value: string) {
+	return value.replace(/\\(\r\n?|\n)/g, "$1");
+}


### PR DESCRIPTION
**Expected code in JavaScript**:
```ts
console.log("Hello\
World!")
```

It should display: `HelloWorld!`

**However, in roblox-ts, it emits an unexpected Luau code provided with the playground link for both literal and template strings**:
https://roblox-ts.com/playground/#code/A4JwlgdgLgFARACQKYBsUHsA6AoA6ukFAEzgEog
https://roblox-ts.com/playground/#code/A4JwlgdgLgFABgCQKYBsUHsA6AoA6ukFAEzgEog

In this PR, when rendering Luau strings, it should strip off the excess `\` if the escape character of a string is `\n`, so it should render Luau code something like this:
```luau
print("Hello\
World")
```

When using template literals, it should output like this:
```luau
print(`Hello
World`)
```