### PR TITLE
Add "v" string for __mode

### DIFF
--- a/src/LuauAST/impl/strings.ts
+++ b/src/LuauAST/impl/strings.ts
@@ -5,7 +5,9 @@ export const strings = {
 	__index: luau.string("__index"),
 	__tostring: luau.string("__tostring"),
 	__mode: luau.string("__mode"),
-	k: luau.string("k"), // used for __mode
+	// used for __mode
+	k: luau.string("k"),
+	v: luau.string("v"),
 
 	// types
 	number: luau.string("number"),


### PR DESCRIPTION
Added a "v" string to the list of constant strings. This addition is necessary for a `WeakRef` implementation I'm making for roblox-ts as a macro.

I'm unsure why not all useful constant Luau strings are in the file. I'd have added all of them, but I rathered stick to how it was already structured.