### PR TITLE
Preserve explicit string quotes and template escapes

### DIFF
--- a/src/LuauAST/impl/create.ts
+++ b/src/LuauAST/impl/create.ts
@@ -8,9 +8,7 @@ type FilteredNodeByKind<T extends keyof luau.NodeByKind> = FilterProps<luau.Node
 // creation
 export function create<T extends keyof luau.NodeByKind>(
 	kind: T,
-	fields: {
-		[K in Exclude<keyof FilteredNodeByKind<T>, keyof luau.Node>]: FilteredNodeByKind<T>[K];
-	},
+	fields: Omit<FilteredNodeByKind<T>, keyof luau.Node>,
 ): luau.NodeByKind[T] {
 	// super hack!
 	const node = Object.assign({ kind }, fields) as unknown as luau.NodeByKind[T];
@@ -93,9 +91,10 @@ export function number(value: number): luau.Expression {
 /**
  * Creates a new `string` literal node.
  * @param value The value of the string
+ * @param quote Explicit delimiter; value must already be escaped for this delimiter.
  */
-export function string(value: string) {
-	return luau.create(luau.SyntaxKind.StringLiteral, { value });
+export function string(value: string, quote?: luau.StringLiteral["quote"]) {
+	return luau.create(luau.SyntaxKind.StringLiteral, { value, quote });
 }
 
 /**

--- a/src/LuauAST/types/nodes.ts
+++ b/src/LuauAST/types/nodes.ts
@@ -53,6 +53,7 @@ export interface NumberLiteral extends luau.BaseExpression<luau.SyntaxKind.Numbe
 
 export interface StringLiteral extends luau.BaseExpression<luau.SyntaxKind.StringLiteral> {
 	value: string;
+	quote?: '"' | "'";
 }
 
 export interface VarArgsLiteral extends luau.BaseExpression<luau.SyntaxKind.VarArgsLiteral> {}

--- a/src/LuauRenderer/nodes/expressions/renderStringLiteral.ts
+++ b/src/LuauRenderer/nodes/expressions/renderStringLiteral.ts
@@ -28,6 +28,10 @@ function needsBracketSpacing(node: luau.StringLiteral) {
 }
 
 export function renderStringLiteral(state: RenderState, node: luau.StringLiteral) {
+	if (node.quote !== undefined) {
+		return `${node.quote}${node.value}${node.quote}`;
+	}
+
 	const isMultiline = node.value.includes("\n");
 	if (!isMultiline && !node.value.includes('"')) {
 		return `"${node.value}"`;

--- a/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
+++ b/src/LuauRenderer/nodes/fields/renderInterpolatedStringPart.ts
@@ -2,11 +2,9 @@ import luau from "LuauAST";
 import { RenderState } from "LuauRenderer";
 
 export function renderInterpolatedStringPart(state: RenderState, node: luau.InterpolatedStringPart) {
-	return (
-		node.text
-			// escape braces, but do not touch braces within unicode escape codes
-			.replace(/(\\u{[a-fA-F0-9]+})|([{}])/g, (_, unicodeEscape, brace) => unicodeEscape ?? "\\" + brace)
-			// escape newlines, captures a CR with optionally an LF after it or just an LF on its own
-			.replace(/(\r\n?|\n)/g, "\\$1")
+	// consume complete escapes so an escaped backslash cannot start a unicode escape
+	return node.text.replace(
+		/(\\(?:u\{[a-fA-F0-9]+\}|\r\n|[\s\S]))|([{}]|\r\n?|\n)/g,
+		(_, escape, character) => escape ?? "\\" + character,
 	);
 }


### PR DESCRIPTION
Allow callers to preserve a string literal's original quote delimiter, and fix interpolated-string rendering when an escaped backslash precedes text that looks like a Unicode escape.

This is the renderer prerequisite for [roblox-ts/roblox-ts#3033](https://github.com/roblox-ts/roblox-ts/pull/3033), the string-literal import/export escaping follow-up to [roblox-ts/roblox-ts#2984](https://github.com/roblox-ts/roblox-ts/pull/2984).

When literal content contains both quote characters, automatic delimiter selection can fall back to long-bracket syntax. That changes the value if the caller supplied source escape sequences, since long-bracket strings do not interpret those escapes. `StringLiteral` now has an optional `quote` field, exposed through `luau.string(value, quote)`. When specified, the renderer uses that delimiter directly; the caller must already have escaped the content for it. Calls without a quote keep the existing delimiter selection.

The `create()` field type now uses `Omit` so optional node fields remain optional for callers.

Interpolated-string rendering now consumes complete escape sequences before escaping literal braces and physical newlines. Previously, the second backslash in `\\u{0041}` could be mistaken for the beginning of a Unicode escape, leaving literal braces unescaped. The new pass preserves escaped backslashes, actual Unicode escapes, and already escaped line breaks while escaping the remaining braces and newlines.

Validation:

- `npm run build` and `npm run eslint` in luau-ast
- `npm test` in the compiler's #3033 branch with this freshly built renderer installed: 142 compiler tests, 2 snapshots, and 496 runtime tests passed
- The compiler regressions cover mixed quotes, exact string spelling, escaped backslashes, Unicode escapes, literal template braces, and line continuations
- `git diff --cached --check`

After this merges and is published, #3033 can bump its pinned renderer dependency.
