### PR TITLE
Use npm trusted publishing

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -12,20 +12,31 @@ jobs:
   publish:
     if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for npm trusted publishing
+      contents: write # required to push the version bump commit and tags
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2.3.4
         with:
           token: ${{ secrets.pat }}
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - name: Update npm
+        run: npm install -g npm@11 # trusted publishing requires npm >= 11.5.1
+
       - name: Install NPM Dependencies
-        uses: bahmutov/npm-install@v1
+        run: npm ci
 
       - name: Publish
         run: |
           git config user.name "GitHub Actions"
           git config user.email "noreply@github.com"
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.npm_token }}" > .npmrc
           npm version ${{ inputs.version }}
           npm publish
           git push


### PR DESCRIPTION
Publish through npm trusted publishing instead of `NPM_TOKEN`. Add OIDC permissions, Node 24/npm 11 setup, and clean dependency installs.

Validation: actionlint; clean install, build, and package dry run with Node 24/npm 11.
