### PR TITLE
feat: report generated positions from the Luau renderer

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -47,6 +47,10 @@ jobs:
           npm install --install-links ../luau-ast
           npm run update-test-types
 
+      - name: Run luau-ast Tests
+        working-directory: luau-ast
+        run: npm test
+
       - name: Run Tests
         run: |
           cd roblox-ts

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # @roblox-ts/luau-ast
+
+`renderAST(ast)` renders a Luau syntax tree to source text. When a consumer also
+needs generated locations, `renderASTWithPositions(ast)` returns the same code
+and an ordered `positions` array with one entry for each emitted node occurrence.
+
+Generated positions use zero-based lines and UTF-16 columns. Each range has an
+inclusive `start` and exclusive `end`. Nodes that emit a closing keyword such as
+`end` or `until` also report its start as `closing`.
+
+```ts
+import luau, { renderASTWithPositions, setNodeOrigin } from "@roblox-ts/luau-ast";
+
+const statement = setNodeOrigin(luau.comment(" generated"), {
+	start: { line: 2, column: 0 },
+});
+const { code, positions } = renderASTWithPositions(luau.list.make(statement));
+```
+
+`setNodeOrigin` attaches optional, source-language-neutral provenance to a node.
+An origin has a `start` and may have a `closing` anchor. Generated nodes can omit
+an origin. Origins survive the shallow clones performed by AST creation and list
+helpers.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	},
 	"scripts": {
 		"prepublishOnly": "npm run build",
+		"prepare": "npm run build",
 		"build": "tspc -b",
 		"build-watch": "tspc -b -w",
 		"eslint": "eslint \"src/**/*.ts\" --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
 		"prepublishOnly": "npm run build",
 		"build": "tspc -b",
 		"build-watch": "tspc -b -w",
-		"eslint": "eslint \"src/**/*.ts\" --max-warnings 0"
+		"eslint": "eslint \"src/**/*.ts\" --max-warnings 0",
+		"test": "npm run build && node --test tests/*.test.js"
 	},
 	"author": "",
 	"license": "MIT",

--- a/src/LuauAST/impl/create.ts
+++ b/src/LuauAST/impl/create.ts
@@ -5,6 +5,12 @@ type AllowedFieldTypes = luau.BaseNode | luau.List<luau.BaseNode> | boolean | nu
 type FilterProps<T, U> = { [K in keyof T]: T[K] extends U ? T[K] : never };
 type FilteredNodeByKind<T extends keyof luau.NodeByKind> = FilterProps<luau.NodeByKind[T], AllowedFieldTypes>;
 
+/** Attaches a source-language range to a node and returns the node. */
+export function setNodeOrigin<T extends luau.Node>(node: T, origin: luau.SourceRange): T {
+	node.origin = origin;
+	return node;
+}
+
 // creation
 export function create<T extends keyof luau.NodeByKind>(
 	kind: T,

--- a/src/LuauAST/impl/create.ts
+++ b/src/LuauAST/impl/create.ts
@@ -6,7 +6,7 @@ type FilterProps<T, U> = { [K in keyof T]: T[K] extends U ? T[K] : never };
 type FilteredNodeByKind<T extends keyof luau.NodeByKind> = FilterProps<luau.NodeByKind[T], AllowedFieldTypes>;
 
 /** Attaches a source-language range to a node and returns the node. */
-export function setNodeOrigin<T extends luau.Node>(node: T, origin: luau.SourceRange): T {
+export function setNodeOrigin<T extends luau.Node>(node: T, origin: luau.NodeOrigin): T {
 	node.origin = origin;
 	return node;
 }

--- a/src/LuauAST/index.ts
+++ b/src/LuauAST/index.ts
@@ -1,4 +1,6 @@
 import * as luau from "LuauAST/bundle";
 export default luau;
 
+export { setNodeOrigin } from "LuauAST/impl/create";
+export type { SourcePosition, SourceRange } from "LuauAST/types/nodes";
 export * from "LuauRenderer";

--- a/src/LuauAST/index.ts
+++ b/src/LuauAST/index.ts
@@ -2,5 +2,5 @@ import * as luau from "LuauAST/bundle";
 export default luau;
 
 export { setNodeOrigin } from "LuauAST/impl/create";
-export type { SourcePosition, SourceRange } from "LuauAST/types/nodes";
+export type { NodeOrigin, SourcePosition } from "LuauAST/types/nodes";
 export * from "LuauRenderer";

--- a/src/LuauAST/types/nodes.ts
+++ b/src/LuauAST/types/nodes.ts
@@ -1,9 +1,20 @@
 import luau from "LuauAST";
 
 // base types
+export interface SourcePosition {
+	line: number;
+	column: number;
+}
+
+export interface SourceRange {
+	start: SourcePosition;
+	end?: SourcePosition;
+}
+
 export interface BaseNode<T extends luau.SyntaxKind = luau.SyntaxKind> {
 	kind: T;
 	parent?: luau.Node;
+	origin?: SourceRange;
 }
 
 export interface BaseIndexableExpression<

--- a/src/LuauAST/types/nodes.ts
+++ b/src/LuauAST/types/nodes.ts
@@ -6,15 +6,15 @@ export interface SourcePosition {
 	column: number;
 }
 
-export interface SourceRange {
+export interface NodeOrigin {
 	start: SourcePosition;
-	end?: SourcePosition;
+	closing?: SourcePosition;
 }
 
 export interface BaseNode<T extends luau.SyntaxKind = luau.SyntaxKind> {
 	kind: T;
 	parent?: luau.Node;
-	origin?: SourceRange;
+	origin?: NodeOrigin;
 }
 
 export interface BaseIndexableExpression<

--- a/src/LuauRenderer/Fragment.ts
+++ b/src/LuauRenderer/Fragment.ts
@@ -152,13 +152,14 @@ export function flattenFragment(fragment: RenderFragment, includePositions = fal
 
 		const active: { node: luau.Node; closing?: GeneratedPosition } = { node: current.node };
 		activeNodes.push(active);
-		const resultIndex = positions.push({
-			node: current.node,
-			range: {
-				start: copyPosition(position),
-				end: copyPosition(position),
-			},
-		}) - 1;
+		const resultIndex =
+			positions.push({
+				node: current.node,
+				range: {
+					start: copyPosition(position),
+					end: copyPosition(position),
+				},
+			}) - 1;
 		stack.push({ kind: "end-node", active, resultIndex }, current.content);
 	}
 	return { code, positions };

--- a/src/LuauRenderer/Fragment.ts
+++ b/src/LuauRenderer/Fragment.ts
@@ -1,0 +1,136 @@
+import luau from "LuauAST";
+
+export interface GeneratedPosition {
+	line: number;
+	column: number;
+}
+
+export interface GeneratedRange {
+	start: GeneratedPosition;
+	end: GeneratedPosition;
+	closing?: GeneratedPosition;
+}
+
+export interface RenderedNodePosition {
+	node: luau.Node;
+	range: GeneratedRange;
+}
+
+interface SequenceFragment {
+	kind: "sequence";
+	parts: ReadonlyArray<RenderFragment>;
+}
+
+interface NodeFragment {
+	kind: "node";
+	node: luau.Node;
+	content: RenderFragment;
+}
+
+interface ClosingFragment {
+	kind: "closing";
+	node: luau.Node;
+}
+
+export type RenderFragment = string | SequenceFragment | NodeFragment | ClosingFragment;
+
+export function concat(...parts: ReadonlyArray<RenderFragment>): RenderFragment {
+	return { kind: "sequence", parts };
+}
+
+export function join(parts: ReadonlyArray<RenderFragment>, separator: string): RenderFragment {
+	const result = new Array<RenderFragment>();
+	for (let index = 0; index < parts.length; index++) {
+		if (index > 0) {
+			result.push(separator);
+		}
+		result.push(parts[index]);
+	}
+	return concat(...result);
+}
+
+export function markNode(node: luau.Node, content: RenderFragment): RenderFragment {
+	return { kind: "node", node, content };
+}
+
+export function markClosing(node: luau.Node): RenderFragment {
+	return { kind: "closing", node };
+}
+
+function copyPosition(position: GeneratedPosition): GeneratedPosition {
+	return { line: position.line, column: position.column };
+}
+
+function advance(position: GeneratedPosition & { previousWasCarriageReturn: boolean }, text: string) {
+	for (let index = 0; index < text.length; index++) {
+		const character = text.charCodeAt(index);
+		if (character === 13) {
+			position.line++;
+			position.column = 0;
+			position.previousWasCarriageReturn = true;
+		} else if (character === 10) {
+			if (!position.previousWasCarriageReturn) {
+				position.line++;
+			}
+			position.column = 0;
+			position.previousWasCarriageReturn = false;
+		} else {
+			position.column++;
+			position.previousWasCarriageReturn = false;
+		}
+	}
+}
+
+export function flattenFragment(fragment: RenderFragment, includePositions = false) {
+	let code = "";
+	const position = { line: 0, column: 0, previousWasCarriageReturn: false };
+	const positions = new Array<RenderedNodePosition>();
+	const activeNodes = new Array<{ node: luau.Node; closing?: GeneratedPosition }>();
+
+	const write = (current: RenderFragment): void => {
+		if (typeof current === "string") {
+			code += current;
+			if (includePositions) {
+				advance(position, current);
+			}
+			return;
+		}
+		if (current.kind === "sequence") {
+			for (const part of current.parts) {
+				write(part);
+			}
+			return;
+		}
+		if (current.kind === "closing") {
+			if (includePositions) {
+				for (let index = activeNodes.length - 1; index >= 0; index--) {
+					const active = activeNodes[index];
+					if (active.node === current.node) {
+						active.closing = copyPosition(position);
+						break;
+					}
+				}
+			}
+			return;
+		}
+
+		const start = copyPosition(position);
+		const active: { node: luau.Node; closing?: GeneratedPosition } = { node: current.node };
+		activeNodes.push(active);
+		write(current.content);
+		if (includePositions) {
+			positions.push({
+				node: current.node,
+				range: {
+					start,
+					end: copyPosition(position),
+					...(active.closing ? { closing: active.closing } : {}),
+				},
+			});
+		}
+		activeNodes.pop();
+	};
+
+	write(fragment);
+	return { code, positions };
+}

--- a/src/LuauRenderer/Fragment.ts
+++ b/src/LuauRenderer/Fragment.ts
@@ -35,10 +35,27 @@ interface ClosingFragment {
 export type RenderFragment = string | SequenceFragment | NodeFragment | ClosingFragment;
 
 export function concat(...parts: ReadonlyArray<RenderFragment>): RenderFragment {
+	let result = "";
+	for (const part of parts) {
+		if (typeof part !== "string") {
+			return { kind: "sequence", parts };
+		}
+		result += part;
+	}
+	return result;
+}
+
+export function sequence(parts: ReadonlyArray<RenderFragment>): RenderFragment {
+	if (parts.every(part => typeof part === "string")) {
+		return (parts as ReadonlyArray<string>).join("");
+	}
 	return { kind: "sequence", parts };
 }
 
 export function join(parts: ReadonlyArray<RenderFragment>, separator: string): RenderFragment {
+	if (parts.every(part => typeof part === "string")) {
+		return (parts as ReadonlyArray<string>).join(separator);
+	}
 	const result = new Array<RenderFragment>();
 	for (let index = 0; index < parts.length; index++) {
 		if (index > 0) {
@@ -46,7 +63,7 @@ export function join(parts: ReadonlyArray<RenderFragment>, separator: string): R
 		}
 		result.push(parts[index]);
 	}
-	return concat(...result);
+	return sequence(result);
 }
 
 export function markNode(node: luau.Node, content: RenderFragment): RenderFragment {
@@ -82,24 +99,30 @@ function advance(position: GeneratedPosition & { previousWasCarriageReturn: bool
 }
 
 export function flattenFragment(fragment: RenderFragment, includePositions = false) {
+	if (typeof fragment === "string") {
+		return { code: fragment, positions: new Array<RenderedNodePosition>() };
+	}
 	let code = "";
 	const position = { line: 0, column: 0, previousWasCarriageReturn: false };
 	const positions = new Array<RenderedNodePosition>();
 	const activeNodes = new Array<{ node: luau.Node; closing?: GeneratedPosition }>();
+	type StackEntry = RenderFragment | { kind: "end-node"; active: (typeof activeNodes)[number]; resultIndex: number };
+	const stack = new Array<StackEntry>(fragment);
 
-	const write = (current: RenderFragment): void => {
+	while (stack.length > 0) {
+		const current = stack.pop()!;
 		if (typeof current === "string") {
 			code += current;
 			if (includePositions) {
 				advance(position, current);
 			}
-			return;
+			continue;
 		}
 		if (current.kind === "sequence") {
-			for (const part of current.parts) {
-				write(part);
+			for (let index = current.parts.length - 1; index >= 0; index--) {
+				stack.push(current.parts[index]);
 			}
-			return;
+			continue;
 		}
 		if (current.kind === "closing") {
 			if (includePositions) {
@@ -111,26 +134,32 @@ export function flattenFragment(fragment: RenderFragment, includePositions = fal
 					}
 				}
 			}
-			return;
+			continue;
+		}
+		if (current.kind === "end-node") {
+			const result = positions[current.resultIndex];
+			result.range.end = copyPosition(position);
+			if (current.active.closing) {
+				result.range.closing = current.active.closing;
+			}
+			activeNodes.pop();
+			continue;
+		}
+		if (!includePositions) {
+			stack.push(current.content);
+			continue;
 		}
 
-		const start = copyPosition(position);
 		const active: { node: luau.Node; closing?: GeneratedPosition } = { node: current.node };
 		activeNodes.push(active);
-		write(current.content);
-		if (includePositions) {
-			positions.push({
-				node: current.node,
-				range: {
-					start,
-					end: copyPosition(position),
-					...(active.closing ? { closing: active.closing } : {}),
-				},
-			});
-		}
-		activeNodes.pop();
-	};
-
-	write(fragment);
+		const resultIndex = positions.push({
+			node: current.node,
+			range: {
+				start: copyPosition(position),
+				end: copyPosition(position),
+			},
+		}) - 1;
+		stack.push({ kind: "end-node", active, resultIndex }, current.content);
+	}
 	return { code, positions };
 }

--- a/src/LuauRenderer/README.md
+++ b/src/LuauRenderer/README.md
@@ -4,10 +4,12 @@ This project takes a Luau AST (from LuauAST) and converts it into Luau source co
 
 ## Structure
 
-**index.ts** - contains the global render function, takes any node and routes it to the appropriate `renderX()` function to turn it into a string
+**render.ts** - routes each node to its `renderX()` function and exposes the string and generated-position rendering APIs
 
-**RenderState.ts** - stores the current state of the render process, instance is passed into every `renderX()` function
+**RenderState.ts** - stores the current rendering state and the shared formatting operations
 
-**nodes/** - folder containing modules that each export a `renderX(state: RenderState, node: luau.X): string` function
+**Fragment.ts** - composes the renderer output and measures node ranges while flattening the emitted text once
+
+**nodes/** - contains each node's layout function; layouts compose fragments that become strings at the public boundary
 
 **util/** - various helper modules to aid in rendering

--- a/src/LuauRenderer/RenderState.ts
+++ b/src/LuauRenderer/RenderState.ts
@@ -1,8 +1,8 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
+import { concat, flattenFragment, markClosing, markNode, RenderFragment } from "LuauRenderer/Fragment";
 import { getEnding } from "LuauRenderer/util/getEnding";
 import { getOrSetDefault } from "LuauRenderer/util/getOrSetDefault";
-import { concat, flattenFragment, markClosing, markNode, RenderFragment } from "LuauRenderer/Fragment";
 
 const INDENT_CHARACTER = "\t";
 const INDENT_CHARACTER_LENGTH = INDENT_CHARACTER.length;

--- a/src/LuauRenderer/RenderState.ts
+++ b/src/LuauRenderer/RenderState.ts
@@ -2,6 +2,7 @@ import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
 import { getEnding } from "LuauRenderer/util/getEnding";
 import { getOrSetDefault } from "LuauRenderer/util/getOrSetDefault";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
 
 const INDENT_CHARACTER = "\t";
 const INDENT_CHARACTER_LENGTH = INDENT_CHARACTER.length;
@@ -99,6 +100,25 @@ export class RenderState {
 	 * @param callback The function used to render the block.
 	 */
 	public block<T>(callback: () => T) {
+		this.pushIndent();
+		const result = callback();
+		this.popIndent();
+		return result;
+	}
+
+	public fragmentNewline(text: RenderFragment): RenderFragment {
+		return concat(text, "\n");
+	}
+
+	public fragmentIndented(text: RenderFragment): RenderFragment {
+		return concat(this.indent, text);
+	}
+
+	public fragmentLine(text: RenderFragment, endNode?: luau.Statement): RenderFragment {
+		return concat(this.fragmentIndented(text), endNode ? getEnding(this, endNode) : "", "\n");
+	}
+
+	public fragmentBlock(callback: () => RenderFragment): RenderFragment {
 		this.pushIndent();
 		const result = callback();
 		this.popIndent();

--- a/src/LuauRenderer/RenderState.ts
+++ b/src/LuauRenderer/RenderState.ts
@@ -2,7 +2,7 @@ import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
 import { getEnding } from "LuauRenderer/util/getEnding";
 import { getOrSetDefault } from "LuauRenderer/util/getOrSetDefault";
-import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { concat, flattenFragment, markClosing, markNode, RenderFragment } from "LuauRenderer/Fragment";
 
 const INDENT_CHARACTER = "\t";
 const INDENT_CHARACTER_LENGTH = INDENT_CHARACTER.length;
@@ -14,6 +14,8 @@ export class RenderState {
 	private indent = "";
 	public seenTempNodes = new Map<number, string>();
 	private readonly listNodesStack = new Array<luau.ListNode<luau.Statement>>();
+
+	public constructor(public readonly includePositions = false) {}
 
 	/**
 	 * Pushes an indent to the current indent level.
@@ -70,7 +72,7 @@ export class RenderState {
 	 * @param text The text.
 	 */
 	public newline(text: string) {
-		return text + "\n";
+		return flattenFragment(this.fragmentNewline(text)).code;
 	}
 
 	/**
@@ -78,7 +80,7 @@ export class RenderState {
 	 * @param text The text.
 	 */
 	public indented(text: string) {
-		return this.indent + text;
+		return flattenFragment(this.fragmentIndented(text)).code;
 	}
 
 	/**
@@ -87,12 +89,7 @@ export class RenderState {
 	 * @param endNode Node used to determine if a semicolon should be added. Undefined means no semi will be added.
 	 */
 	public line(text: string, endNode?: luau.Statement) {
-		let result = this.indented(text);
-		if (endNode) {
-			result += getEnding(this, endNode);
-		}
-		result = this.newline(result);
-		return result;
+		return flattenFragment(this.fragmentLine(text, endNode)).code;
 	}
 
 	/**
@@ -118,10 +115,11 @@ export class RenderState {
 		return concat(this.fragmentIndented(text), endNode ? getEnding(this, endNode) : "", "\n");
 	}
 
-	public fragmentBlock(callback: () => RenderFragment): RenderFragment {
-		this.pushIndent();
-		const result = callback();
-		this.popIndent();
-		return result;
+	public fragmentClosing(node: luau.Node): RenderFragment {
+		return this.includePositions ? markClosing(node) : "";
+	}
+
+	public fragmentNode(node: luau.Node, content: RenderFragment): RenderFragment {
+		return this.includePositions ? markNode(node, content) : content;
 	}
 }

--- a/src/LuauRenderer/RenderState.ts
+++ b/src/LuauRenderer/RenderState.ts
@@ -119,6 +119,10 @@ export class RenderState {
 		return this.includePositions ? markClosing(node) : "";
 	}
 
+	public fragmentClosingLine(node: luau.Node, text: RenderFragment): RenderFragment {
+		return this.fragmentLine(concat(this.fragmentClosing(node), text));
+	}
+
 	public fragmentNode(node: luau.Node, content: RenderFragment): RenderFragment {
 		return this.includePositions ? markNode(node, content) : content;
 	}

--- a/src/LuauRenderer/index.ts
+++ b/src/LuauRenderer/index.ts
@@ -1,4 +1,5 @@
 export * from "LuauRenderer/render";
+export type { GeneratedPosition, GeneratedRange, RenderedNodePosition } from "LuauRenderer/Fragment";
 export * from "LuauRenderer/RenderState";
 export * from "LuauRenderer/solveTempIds";
 export * from "LuauRenderer/util/renderStatements";

--- a/src/LuauRenderer/index.ts
+++ b/src/LuauRenderer/index.ts
@@ -1,5 +1,6 @@
-export * from "LuauRenderer/render";
 export type { GeneratedPosition, GeneratedRange, RenderedNodePosition } from "LuauRenderer/Fragment";
+export type { RenderResultWithPositions } from "LuauRenderer/render";
+export { render, renderAST, renderASTWithPositions } from "LuauRenderer/render";
 export * from "LuauRenderer/RenderState";
 export * from "LuauRenderer/solveTempIds";
-export * from "LuauRenderer/util/renderStatements";
+export { renderStatements } from "LuauRenderer/util/renderStatements";

--- a/src/LuauRenderer/nodes/expressions/indexable/renderCallExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/indexable/renderCallExpression.ts
@@ -1,7 +1,9 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
-import { renderArguments } from "LuauRenderer/util/renderArguments";
+import { concat } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderArgumentsFragment } from "LuauRenderer/util/renderArguments";
 
 export function renderCallExpression(state: RenderState, node: luau.CallExpression) {
-	return `${render(state, node.expression)}(${renderArguments(state, node.args)})`;
+	return concat(renderNode(state, node.expression), "(", renderArgumentsFragment(state, node.args), ")");
 }

--- a/src/LuauRenderer/nodes/expressions/indexable/renderComputedIndexExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/indexable/renderComputedIndexExpression.ts
@@ -1,12 +1,13 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, markNode } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderComputedIndexExpression(state: RenderState, node: luau.ComputedIndexExpression) {
-	const expStr = render(state, node.expression);
+	const expression = renderNode(state, node.expression);
 	if (luau.isStringLiteral(node.index) && luau.isValidIdentifier(node.index.value)) {
-		return `${expStr}.${node.index.value}`;
+		return concat(expression, ".", markNode(node.index, node.index.value));
 	} else {
-		const indexStr = render(state, node.index);
-		return `${expStr}[${indexStr}]`;
+		return concat(expression, "[", renderNode(state, node.index), "]");
 	}
 }

--- a/src/LuauRenderer/nodes/expressions/indexable/renderComputedIndexExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/indexable/renderComputedIndexExpression.ts
@@ -1,12 +1,12 @@
 import luau from "LuauAST";
-import { concat, markNode } from "LuauRenderer/Fragment";
+import { concat } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderComputedIndexExpression(state: RenderState, node: luau.ComputedIndexExpression) {
 	const expression = renderNode(state, node.expression);
 	if (luau.isStringLiteral(node.index) && luau.isValidIdentifier(node.index.value)) {
-		return concat(expression, ".", markNode(node.index, node.index.value));
+		return concat(expression, ".", state.fragmentNode(node.index, node.index.value));
 	} else {
 		return concat(expression, "[", renderNode(state, node.index), "]");
 	}

--- a/src/LuauRenderer/nodes/expressions/indexable/renderMethodCallExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/indexable/renderMethodCallExpression.ts
@@ -1,9 +1,11 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
-import { render, RenderState } from "LuauRenderer";
-import { renderArguments } from "LuauRenderer/util/renderArguments";
+import { concat } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderArgumentsFragment } from "LuauRenderer/util/renderArguments";
 
 export function renderMethodCallExpression(state: RenderState, node: luau.MethodCallExpression) {
 	assert(luau.isValidIdentifier(node.name));
-	return `${render(state, node.expression)}:${node.name}(${renderArguments(state, node.args)})`;
+	return concat(renderNode(state, node.expression), `:${node.name}(`, renderArgumentsFragment(state, node.args), ")");
 }

--- a/src/LuauRenderer/nodes/expressions/indexable/renderParenthesizedExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/indexable/renderParenthesizedExpression.ts
@@ -1,5 +1,7 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderParenthesizedExpression(state: RenderState, node: luau.ParenthesizedExpression) {
 	// skip nested parentheses
@@ -8,8 +10,8 @@ export function renderParenthesizedExpression(state: RenderState, node: luau.Par
 		expression = expression.expression;
 	}
 	if (luau.isSimple(expression)) {
-		return render(state, node.expression);
+		return renderNode(state, node.expression);
 	} else {
-		return `(${render(state, node.expression)})`;
+		return concat("(", renderNode(state, node.expression), ")");
 	}
 }

--- a/src/LuauRenderer/nodes/expressions/indexable/renderPropertyAccessExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/indexable/renderPropertyAccessExpression.ts
@@ -1,12 +1,14 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderPropertyAccessExpression(state: RenderState, node: luau.PropertyAccessExpression) {
-	const expStr = render(state, node.expression);
+	const expression = renderNode(state, node.expression);
 	const nameStr = node.name;
 	if (luau.isValidIdentifier(nameStr)) {
-		return `${expStr}.${nameStr}`;
+		return concat(expression, `.${nameStr}`);
 	} else {
-		return `${expStr}["${nameStr}"]`;
+		return concat(expression, `["${nameStr}"]`);
 	}
 }

--- a/src/LuauRenderer/nodes/expressions/renderArray.ts
+++ b/src/LuauRenderer/nodes/expressions/renderArray.ts
@@ -1,11 +1,13 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, join } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderArray(state: RenderState, node: luau.Array) {
 	if (luau.list.isEmpty(node.members)) {
 		return "{}";
 	}
 
-	const membersStr = luau.list.mapToArray(node.members, member => render(state, member)).join(", ");
-	return `{ ${membersStr} }`;
+	const members = luau.list.mapToArray(node.members, member => renderNode(state, member));
+	return concat("{ ", join(members, ", "), " }");
 }

--- a/src/LuauRenderer/nodes/expressions/renderBinaryExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderBinaryExpression.ts
@@ -5,7 +5,11 @@ import { RenderState } from "LuauRenderer/RenderState";
 import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
 export function renderBinaryExpression(state: RenderState, node: luau.BinaryExpression) {
-	let result: RenderFragment = concat(renderNode(state, node.left), ` ${node.operator} `, renderNode(state, node.right));
+	let result: RenderFragment = concat(
+		renderNode(state, node.left),
+		` ${node.operator} `,
+		renderNode(state, node.right),
+	);
 
 	if (needsParentheses(node)) {
 		result = concat("(", result, ")");

--- a/src/LuauRenderer/nodes/expressions/renderBinaryExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderBinaryExpression.ts
@@ -1,12 +1,14 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
 export function renderBinaryExpression(state: RenderState, node: luau.BinaryExpression) {
-	let result = `${render(state, node.left)} ${node.operator} ${render(state, node.right)}`;
+	let result: RenderFragment = concat(renderNode(state, node.left), ` ${node.operator} `, renderNode(state, node.right));
 
 	if (needsParentheses(node)) {
-		result = `(${result})`;
+		result = concat("(", result, ")");
 	}
 
 	return result;

--- a/src/LuauRenderer/nodes/expressions/renderFunctionExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderFunctionExpression.ts
@@ -1,16 +1,18 @@
 import luau from "LuauAST";
-import { RenderState } from "LuauRenderer";
-import { renderParameters } from "LuauRenderer/util/renderParameters";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, markClosing } from "LuauRenderer/Fragment";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderParametersFragment } from "LuauRenderer/util/renderParameters";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderFunctionExpression(state: RenderState, node: luau.FunctionExpression) {
 	if (luau.list.isEmpty(node.statements)) {
-		return `function(${renderParameters(state, node)}) end`;
+		return concat("function(", renderParametersFragment(state, node), ") ", markClosing(node), "end");
 	}
 
-	let result = "";
-	result += state.newline(`function(${renderParameters(state, node)})`);
-	result += state.block(() => renderStatements(state, node.statements));
-	result += state.indented(`end`);
-	return result;
+	return concat(
+		state.fragmentNewline(concat("function(", renderParametersFragment(state, node), ")")),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+		markClosing(node),
+		state.fragmentIndented("end"),
+	);
 }

--- a/src/LuauRenderer/nodes/expressions/renderFunctionExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderFunctionExpression.ts
@@ -1,18 +1,18 @@
 import luau from "LuauAST";
-import { concat, markClosing } from "LuauRenderer/Fragment";
+import { concat } from "LuauRenderer/Fragment";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderParametersFragment } from "LuauRenderer/util/renderParameters";
 import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderFunctionExpression(state: RenderState, node: luau.FunctionExpression) {
 	if (luau.list.isEmpty(node.statements)) {
-		return concat("function(", renderParametersFragment(state, node), ") ", markClosing(node), "end");
+		return concat("function(", renderParametersFragment(state, node), ") ", state.fragmentClosing(node), "end");
 	}
 
 	return concat(
 		state.fragmentNewline(concat("function(", renderParametersFragment(state, node), ")")),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-		markClosing(node),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		state.fragmentClosing(node),
 		state.fragmentIndented("end"),
 	);
 }

--- a/src/LuauRenderer/nodes/expressions/renderFunctionExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderFunctionExpression.ts
@@ -12,7 +12,6 @@ export function renderFunctionExpression(state: RenderState, node: luau.Function
 	return concat(
 		state.fragmentNewline(concat("function(", renderParametersFragment(state, node), ")")),
 		state.block(() => renderStatementsFragment(state, node.statements)),
-		state.fragmentClosing(node),
-		state.fragmentIndented("end"),
+		state.fragmentIndented(concat(state.fragmentClosing(node), "end")),
 	);
 }

--- a/src/LuauRenderer/nodes/expressions/renderIfExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderIfExpression.ts
@@ -1,22 +1,40 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, markNode, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
 export function renderIfExpression(state: RenderState, node: luau.IfExpression) {
-	let result = `if ${render(state, node.condition)} then ${render(state, node.expression)} `;
+	let result: RenderFragment = concat(
+		"if ",
+		renderNode(state, node.condition),
+		" then ",
+		renderNode(state, node.expression),
+		" ",
+	);
 
 	let currentAlternative = node.alternative;
 	while (luau.isIfExpression(currentAlternative)) {
-		const condition = render(state, currentAlternative.condition);
-		const expression = render(state, currentAlternative.expression);
-		result += `elseif ${condition} then ${expression} `;
+		result = concat(
+			result,
+			markNode(
+				currentAlternative,
+				concat(
+					"elseif ",
+					renderNode(state, currentAlternative.condition),
+					" then ",
+					renderNode(state, currentAlternative.expression),
+					" ",
+				),
+			),
+		);
 		currentAlternative = currentAlternative.alternative;
 	}
 
-	result += `else ${render(state, currentAlternative)}`;
+	result = concat(result, "else ", renderNode(state, currentAlternative));
 
 	if (needsParentheses(node)) {
-		result = `(${result})`;
+		result = concat("(", result, ")");
 	}
 
 	return result;

--- a/src/LuauRenderer/nodes/expressions/renderIfExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderIfExpression.ts
@@ -1,37 +1,39 @@
 import luau from "LuauAST";
-import { concat, markNode, RenderFragment } from "LuauRenderer/Fragment";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
 export function renderIfExpression(state: RenderState, node: luau.IfExpression) {
-	let result: RenderFragment = concat(
+	let result: RenderFragment;
+	const alternatives = new Array<{ node: luau.IfExpression; content: RenderFragment }>();
+	let currentAlternative = node.alternative;
+	while (luau.isIfExpression(currentAlternative)) {
+		alternatives.push({
+			node: currentAlternative,
+			content: concat(
+				"elseif ",
+				renderNode(state, currentAlternative.condition),
+				" then ",
+				renderNode(state, currentAlternative.expression),
+				" ",
+			),
+		});
+		currentAlternative = currentAlternative.alternative;
+	}
+	result = concat("else ", renderNode(state, currentAlternative));
+	for (let index = alternatives.length - 1; index >= 0; index--) {
+		const alternative = alternatives[index];
+		result = state.fragmentNode(alternative.node, concat(alternative.content, result));
+	}
+	result = concat(
 		"if ",
 		renderNode(state, node.condition),
 		" then ",
 		renderNode(state, node.expression),
 		" ",
+		result,
 	);
-
-	let currentAlternative = node.alternative;
-	while (luau.isIfExpression(currentAlternative)) {
-		result = concat(
-			result,
-			markNode(
-				currentAlternative,
-				concat(
-					"elseif ",
-					renderNode(state, currentAlternative.condition),
-					" then ",
-					renderNode(state, currentAlternative.expression),
-					" ",
-				),
-			),
-		);
-		currentAlternative = currentAlternative.alternative;
-	}
-
-	result = concat(result, "else ", renderNode(state, currentAlternative));
 
 	if (needsParentheses(node)) {
 		result = concat("(", result, ")");

--- a/src/LuauRenderer/nodes/expressions/renderInterpolatedString.ts
+++ b/src/LuauRenderer/nodes/expressions/renderInterpolatedString.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { concat, RenderFragment, sequence } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 
@@ -19,5 +19,5 @@ export function renderInterpolatedString(state: RenderState, node: luau.Interpol
 		}
 	});
 	result.push("`");
-	return concat(...result);
+	return sequence(result);
 }

--- a/src/LuauRenderer/nodes/expressions/renderInterpolatedString.ts
+++ b/src/LuauRenderer/nodes/expressions/renderInterpolatedString.ts
@@ -1,22 +1,23 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderInterpolatedString(state: RenderState, node: luau.InterpolatedString) {
-	let result = "`";
+	const result = new Array<RenderFragment>("`");
 	luau.list.forEach(node.parts, part => {
-		let expressionStr = render(state, part);
+		let expression = renderNode(state, part);
 		if (luau.isInterpolatedStringPart(part)) {
-			result += expressionStr;
+			result.push(expression);
 		} else {
-			result += "{";
+			result.push("{");
 			// `{{}}` is invalid, so we wrap it in parenthesis
 			if (luau.isTable(part)) {
-				expressionStr = `(${expressionStr})`;
+				expression = concat("(", expression, ")");
 			}
-			result += expressionStr;
-			result += "}";
+			result.push(expression, "}");
 		}
 	});
-	result += "`";
-	return result;
+	result.push("`");
+	return concat(...result);
 }

--- a/src/LuauRenderer/nodes/expressions/renderMap.ts
+++ b/src/LuauRenderer/nodes/expressions/renderMap.ts
@@ -1,15 +1,17 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderMap(state: RenderState, node: luau.Map) {
 	if (luau.list.isEmpty(node.fields)) {
 		return "{}";
 	}
 
-	let result = "{\n";
+	const fields = new Array<RenderFragment>();
 	state.block(() => {
-		luau.list.forEach(node.fields, field => (result += state.line(`${render(state, field)},`)));
+		luau.list.forEach(node.fields, field => fields.push(state.fragmentLine(concat(renderNode(state, field), ","))));
+		return "";
 	});
-	result += state.indented("}");
-	return result;
+	return concat("{\n", ...fields, state.fragmentIndented("}"));
 }

--- a/src/LuauRenderer/nodes/expressions/renderMap.ts
+++ b/src/LuauRenderer/nodes/expressions/renderMap.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { concat, RenderFragment, sequence } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 
@@ -13,5 +13,5 @@ export function renderMap(state: RenderState, node: luau.Map) {
 		luau.list.forEach(node.fields, field => fields.push(state.fragmentLine(concat(renderNode(state, field), ","))));
 		return "";
 	});
-	return concat("{\n", ...fields, state.fragmentIndented("}"));
+	return sequence(["{\n", ...fields, state.fragmentIndented("}")]);
 }

--- a/src/LuauRenderer/nodes/expressions/renderMixedTable.ts
+++ b/src/LuauRenderer/nodes/expressions/renderMixedTable.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { concat, RenderFragment, sequence } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 
@@ -16,5 +16,5 @@ export function renderMixedTable(state: RenderState, node: luau.MixedTable) {
 		);
 		return "";
 	});
-	return concat("{\n", ...fields, state.fragmentIndented("}"));
+	return sequence(["{\n", ...fields, state.fragmentIndented("}")]);
 }

--- a/src/LuauRenderer/nodes/expressions/renderMixedTable.ts
+++ b/src/LuauRenderer/nodes/expressions/renderMixedTable.ts
@@ -1,16 +1,20 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderMixedTable(state: RenderState, node: luau.MixedTable) {
 	if (luau.list.isEmpty(node.fields)) {
 		return "{}";
 	}
 
-	let result = "{\n";
+	const fields = new Array<RenderFragment>();
 	state.block(() => {
 		// temp fix for https://github.com/microsoft/TypeScript/issues/42932
-		luau.list.forEach(node.fields, field => (result += state.line(`${render(state, field as luau.Node)},`)));
+		luau.list.forEach(node.fields, field =>
+			fields.push(state.fragmentLine(concat(renderNode(state, field as luau.Node), ","))),
+		);
+		return "";
 	});
-	result += state.indented("}");
-	return result;
+	return concat("{\n", ...fields, state.fragmentIndented("}"));
 }

--- a/src/LuauRenderer/nodes/expressions/renderSet.ts
+++ b/src/LuauRenderer/nodes/expressions/renderSet.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { concat, RenderFragment, sequence } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 
@@ -15,5 +15,5 @@ export function renderSet(state: RenderState, node: luau.Set) {
 		);
 		return "";
 	});
-	return concat("{\n", ...members, state.fragmentIndented("}"));
+	return sequence(["{\n", ...members, state.fragmentIndented("}")]);
 }

--- a/src/LuauRenderer/nodes/expressions/renderSet.ts
+++ b/src/LuauRenderer/nodes/expressions/renderSet.ts
@@ -1,15 +1,19 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderSet(state: RenderState, node: luau.Set) {
 	if (luau.list.isEmpty(node.members)) {
 		return "{}";
 	}
 
-	let result = "{\n";
+	const members = new Array<RenderFragment>();
 	state.block(() => {
-		luau.list.forEach(node.members, member => (result += state.line(`[${render(state, member)}] = true,`)));
+		luau.list.forEach(node.members, member =>
+			members.push(state.fragmentLine(concat("[", renderNode(state, member), "] = true,"))),
+		);
+		return "";
 	});
-	result += state.indented("}");
-	return result;
+	return concat("{\n", ...members, state.fragmentIndented("}"));
 }

--- a/src/LuauRenderer/nodes/expressions/renderUnaryExpression.ts
+++ b/src/LuauRenderer/nodes/expressions/renderUnaryExpression.ts
@@ -1,5 +1,7 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 import { needsParentheses } from "LuauRenderer/util/needsParentheses";
 
 function needsSpace(node: luau.UnaryExpression) {
@@ -23,9 +25,9 @@ export function renderUnaryExpression(state: RenderState, node: luau.UnaryExpres
 		opStr += " ";
 	}
 
-	let result = `${opStr}${render(state, node.expression)}`;
+	let result: RenderFragment = concat(opStr, renderNode(state, node.expression));
 	if (needsParentheses(node)) {
-		result = `(${result})`;
+		result = concat("(", result, ")");
 	}
 
 	return result;

--- a/src/LuauRenderer/nodes/fields/renderMapField.ts
+++ b/src/LuauRenderer/nodes/fields/renderMapField.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, markNode } from "LuauRenderer/Fragment";
+import { concat } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 
@@ -7,7 +7,7 @@ export function renderMapField(state: RenderState, node: luau.MapField) {
 	const { index, value } = node;
 	const renderedValue = renderNode(state, value);
 	if (luau.isStringLiteral(index) && luau.isValidIdentifier(index.value)) {
-		return concat(markNode(index, index.value), " = ", renderedValue);
+		return concat(state.fragmentNode(index, index.value), " = ", renderedValue);
 	} else {
 		return concat("[", renderNode(state, index), "] = ", renderedValue);
 	}

--- a/src/LuauRenderer/nodes/fields/renderMapField.ts
+++ b/src/LuauRenderer/nodes/fields/renderMapField.ts
@@ -1,13 +1,14 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, markNode } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderMapField(state: RenderState, node: luau.MapField) {
 	const { index, value } = node;
-	const valueStr = render(state, value);
+	const renderedValue = renderNode(state, value);
 	if (luau.isStringLiteral(index) && luau.isValidIdentifier(index.value)) {
-		return `${index.value} = ${valueStr}`;
+		return concat(markNode(index, index.value), " = ", renderedValue);
 	} else {
-		const indexStr = render(state, index);
-		return `[${indexStr}] = ${valueStr}`;
+		return concat("[", renderNode(state, index), "] = ", renderedValue);
 	}
 }

--- a/src/LuauRenderer/nodes/statements/renderAssignment.ts
+++ b/src/LuauRenderer/nodes/statements/renderAssignment.ts
@@ -1,23 +1,31 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
-import { render, RenderState } from "LuauRenderer";
+import { concat, join, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderAssignment(state: RenderState, node: luau.Assignment) {
-	let leftStr: string;
+	let left: RenderFragment;
 	if (luau.list.isList(node.left)) {
 		assert(!luau.list.isEmpty(node.left));
-		leftStr = luau.list.mapToArray(node.left, id => render(state, id)).join(", ");
+		left = join(
+			luau.list.mapToArray(node.left, identifier => renderNode(state, identifier)),
+			", ",
+		);
 	} else {
-		leftStr = render(state, node.left);
+		left = renderNode(state, node.left);
 	}
 
-	let rightStr: string;
+	let right: RenderFragment;
 	if (luau.list.isList(node.right)) {
 		assert(!luau.list.isEmpty(node.right));
-		rightStr = luau.list.mapToArray(node.right, expression => render(state, expression)).join(", ");
+		right = join(
+			luau.list.mapToArray(node.right, expression => renderNode(state, expression)),
+			", ",
+		);
 	} else {
-		rightStr = render(state, node.right);
+		right = renderNode(state, node.right);
 	}
 
-	return state.line(`${leftStr} ${node.operator} ${rightStr}`, node);
+	return state.fragmentLine(concat(left, ` ${node.operator} `, right), node);
 }

--- a/src/LuauRenderer/nodes/statements/renderCallStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderCallStatement.ts
@@ -1,6 +1,7 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderCallStatement(state: RenderState, node: luau.CallStatement) {
-	return state.line(`${render(state, node.expression)}`, node);
+	return state.fragmentLine(renderNode(state, node.expression), node);
 }

--- a/src/LuauRenderer/nodes/statements/renderDoStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderDoStatement.ts
@@ -1,13 +1,13 @@
 import luau from "LuauAST";
-import { concat, markClosing } from "LuauRenderer/Fragment";
+import { concat } from "LuauRenderer/Fragment";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderDoStatement(state: RenderState, node: luau.DoStatement) {
 	return concat(
 		state.fragmentLine("do"),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-		markClosing(node),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		state.fragmentClosing(node),
 		state.fragmentLine("end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderDoStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderDoStatement.ts
@@ -1,11 +1,13 @@
 import luau from "LuauAST";
-import { RenderState } from "LuauRenderer";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, markClosing } from "LuauRenderer/Fragment";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderDoStatement(state: RenderState, node: luau.DoStatement) {
-	let result = "";
-	result += state.line(`do`);
-	result += state.block(() => renderStatements(state, node.statements));
-	result += state.line(`end`);
-	return result;
+	return concat(
+		state.fragmentLine("do"),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+		markClosing(node),
+		state.fragmentLine("end"),
+	);
 }

--- a/src/LuauRenderer/nodes/statements/renderDoStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderDoStatement.ts
@@ -7,7 +7,6 @@ export function renderDoStatement(state: RenderState, node: luau.DoStatement) {
 	return concat(
 		state.fragmentLine("do"),
 		state.block(() => renderStatementsFragment(state, node.statements)),
-		state.fragmentClosing(node),
-		state.fragmentLine("end"),
+		state.fragmentClosingLine(node, "end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderForStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderForStatement.ts
@@ -1,15 +1,20 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, join, markClosing } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderForStatement(state: RenderState, node: luau.ForStatement) {
-	const idsStr = luau.list.mapToArray(node.ids, id => render(state, id)).join(", ") || "_";
-	const expStr = render(state, node.expression);
-
-	let result = "";
-	result += state.line(`for ${idsStr} in ${expStr} do`);
-	result += state.block(() => renderStatements(state, node.statements));
-	result += state.line(`end`);
-
-	return result;
+	const identifiers = luau.list.isEmpty(node.ids)
+		? "_"
+		: join(
+				luau.list.mapToArray(node.ids, identifier => renderNode(state, identifier)),
+				", ",
+			);
+	return concat(
+		state.fragmentLine(concat("for ", identifiers, " in ", renderNode(state, node.expression), " do")),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+		markClosing(node),
+		state.fragmentLine("end"),
+	);
 }

--- a/src/LuauRenderer/nodes/statements/renderForStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderForStatement.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, join, markClosing } from "LuauRenderer/Fragment";
+import { concat, join } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
@@ -13,8 +13,8 @@ export function renderForStatement(state: RenderState, node: luau.ForStatement) 
 			);
 	return concat(
 		state.fragmentLine(concat("for ", identifiers, " in ", renderNode(state, node.expression), " do")),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-		markClosing(node),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		state.fragmentClosing(node),
 		state.fragmentLine("end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderForStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderForStatement.ts
@@ -14,7 +14,6 @@ export function renderForStatement(state: RenderState, node: luau.ForStatement) 
 	return concat(
 		state.fragmentLine(concat("for ", identifiers, " in ", renderNode(state, node.expression), " do")),
 		state.block(() => renderStatementsFragment(state, node.statements)),
-		state.fragmentClosing(node),
-		state.fragmentLine("end"),
+		state.fragmentClosingLine(node, "end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderFunctionDeclaration.ts
+++ b/src/LuauRenderer/nodes/statements/renderFunctionDeclaration.ts
@@ -21,7 +21,6 @@ export function renderFunctionDeclaration(state: RenderState, node: luau.Functio
 			),
 		),
 		state.block(() => renderStatementsFragment(state, node.statements)),
-		state.fragmentClosing(node),
-		state.fragmentLine("end"),
+		state.fragmentClosingLine(node, "end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderFunctionDeclaration.ts
+++ b/src/LuauRenderer/nodes/statements/renderFunctionDeclaration.ts
@@ -1,6 +1,6 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
-import { concat, markClosing } from "LuauRenderer/Fragment";
+import { concat } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderParametersFragment } from "LuauRenderer/util/renderParameters";
@@ -20,8 +20,8 @@ export function renderFunctionDeclaration(state: RenderState, node: luau.Functio
 				")",
 			),
 		),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-		markClosing(node),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		state.fragmentClosing(node),
 		state.fragmentLine("end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderFunctionDeclaration.ts
+++ b/src/LuauRenderer/nodes/statements/renderFunctionDeclaration.ts
@@ -1,19 +1,27 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
-import { render, RenderState } from "LuauRenderer";
-import { renderParameters } from "LuauRenderer/util/renderParameters";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, markClosing } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderParametersFragment } from "LuauRenderer/util/renderParameters";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderFunctionDeclaration(state: RenderState, node: luau.FunctionDeclaration) {
 	if (node.localize) {
 		assert(luau.isAnyIdentifier(node.name), "local function cannot be a property");
 	}
-	const nameStr = render(state, node.name);
-	const paramStr = renderParameters(state, node);
-
-	let result = "";
-	result += state.line(`${node.localize ? "local " : ""}function ${nameStr}(${paramStr})`);
-	result += state.block(() => renderStatements(state, node.statements));
-	result += state.line(`end`);
-	return result;
+	return concat(
+		state.fragmentLine(
+			concat(
+				node.localize ? "local function " : "function ",
+				renderNode(state, node.name),
+				"(",
+				renderParametersFragment(state, node),
+				")",
+			),
+		),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+		markClosing(node),
+		state.fragmentLine("end"),
+	);
 }

--- a/src/LuauRenderer/nodes/statements/renderIfStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderIfStatement.ts
@@ -36,7 +36,6 @@ export function renderIfStatement(state: RenderState, node: luau.IfStatement) {
 		state.fragmentLine(concat("if ", renderNode(state, node.condition), " then")),
 		state.block(() => renderStatementsFragment(state, node.statements)),
 		alternative,
-		state.fragmentClosing(node),
-		state.fragmentLine("end"),
+		state.fragmentClosingLine(node, "end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderIfStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderIfStatement.ts
@@ -1,28 +1,36 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, markClosing, markNode, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderIfStatement(state: RenderState, node: luau.IfStatement) {
-	let result = "";
-
-	result += state.line(`if ${render(state, node.condition)} then`);
-	result += state.block(() => renderStatements(state, node.statements));
+	const result = new Array<RenderFragment>(
+		state.fragmentLine(concat("if ", renderNode(state, node.condition), " then")),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+	);
 
 	let currentElseBody = node.elseBody;
 	while (luau.isNode(currentElseBody)) {
 		const statements = currentElseBody.statements;
-		result += state.line(`elseif ${render(state, currentElseBody.condition)} then`);
-		result += state.block(() => renderStatements(state, statements));
+		result.push(
+			markNode(
+				currentElseBody,
+				concat(
+					state.fragmentLine(concat("elseif ", renderNode(state, currentElseBody.condition), " then")),
+					state.fragmentBlock(() => renderStatementsFragment(state, statements)),
+				),
+			),
+		);
 		currentElseBody = currentElseBody.elseBody;
 	}
 
 	if (currentElseBody && luau.list.isNonEmpty(currentElseBody)) {
-		result += state.line(`else`);
+		result.push(state.fragmentLine("else"));
 		const statements = currentElseBody;
-		result += state.block(() => renderStatements(state, statements));
+		result.push(state.fragmentBlock(() => renderStatementsFragment(state, statements)));
 	}
 
-	result += state.line(`end`);
-
-	return result;
+	result.push(markClosing(node), state.fragmentLine("end"));
+	return concat(...result);
 }

--- a/src/LuauRenderer/nodes/statements/renderIfStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderIfStatement.ts
@@ -1,36 +1,42 @@
 import luau from "LuauAST";
-import { concat, markClosing, markNode, RenderFragment } from "LuauRenderer/Fragment";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderIfStatement(state: RenderState, node: luau.IfStatement) {
-	const result = new Array<RenderFragment>(
-		state.fragmentLine(concat("if ", renderNode(state, node.condition), " then")),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-	);
-
+	const alternatives = new Array<{ node: luau.IfStatement; content: RenderFragment }>();
 	let currentElseBody = node.elseBody;
 	while (luau.isNode(currentElseBody)) {
-		const statements = currentElseBody.statements;
-		result.push(
-			markNode(
-				currentElseBody,
-				concat(
-					state.fragmentLine(concat("elseif ", renderNode(state, currentElseBody.condition), " then")),
-					state.fragmentBlock(() => renderStatementsFragment(state, statements)),
-				),
+		const elseifNode = currentElseBody;
+		alternatives.push({
+			node: elseifNode,
+			content: concat(
+				state.fragmentLine(concat("elseif ", renderNode(state, elseifNode.condition), " then")),
+				state.block(() => renderStatementsFragment(state, elseifNode.statements)),
 			),
-		);
+		});
 		currentElseBody = currentElseBody.elseBody;
 	}
 
+	let alternative: RenderFragment = "";
 	if (currentElseBody && luau.list.isNonEmpty(currentElseBody)) {
-		result.push(state.fragmentLine("else"));
-		const statements = currentElseBody;
-		result.push(state.fragmentBlock(() => renderStatementsFragment(state, statements)));
+		const elseStatements = currentElseBody;
+		alternative = concat(
+			state.fragmentLine("else"),
+			state.block(() => renderStatementsFragment(state, elseStatements)),
+		);
+	}
+	for (let index = alternatives.length - 1; index >= 0; index--) {
+		const elseifNode = alternatives[index];
+		alternative = state.fragmentNode(elseifNode.node, concat(elseifNode.content, alternative));
 	}
 
-	result.push(markClosing(node), state.fragmentLine("end"));
-	return concat(...result);
+	return concat(
+		state.fragmentLine(concat("if ", renderNode(state, node.condition), " then")),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		alternative,
+		state.fragmentClosing(node),
+		state.fragmentLine("end"),
+	);
 }

--- a/src/LuauRenderer/nodes/statements/renderMethodDeclaration.ts
+++ b/src/LuauRenderer/nodes/statements/renderMethodDeclaration.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, markClosing } from "LuauRenderer/Fragment";
+import { concat } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderParametersFragment } from "LuauRenderer/util/renderParameters";
@@ -16,8 +16,8 @@ export function renderMethodDeclaration(state: RenderState, node: luau.MethodDec
 				")",
 			),
 		),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-		markClosing(node),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		state.fragmentClosing(node),
 		state.fragmentLine("end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderMethodDeclaration.ts
+++ b/src/LuauRenderer/nodes/statements/renderMethodDeclaration.ts
@@ -17,7 +17,6 @@ export function renderMethodDeclaration(state: RenderState, node: luau.MethodDec
 			),
 		),
 		state.block(() => renderStatementsFragment(state, node.statements)),
-		state.fragmentClosing(node),
-		state.fragmentLine("end"),
+		state.fragmentClosingLine(node, "end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderMethodDeclaration.ts
+++ b/src/LuauRenderer/nodes/statements/renderMethodDeclaration.ts
@@ -1,12 +1,23 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
-import { renderParameters } from "LuauRenderer/util/renderParameters";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, markClosing } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderParametersFragment } from "LuauRenderer/util/renderParameters";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderMethodDeclaration(state: RenderState, node: luau.MethodDeclaration) {
-	let result = "";
-	result += state.line(`function ${render(state, node.expression)}:${node.name}(${renderParameters(state, node)})`);
-	result += state.block(() => renderStatements(state, node.statements));
-	result += state.line(`end`);
-	return result;
+	return concat(
+		state.fragmentLine(
+			concat(
+				"function ",
+				renderNode(state, node.expression),
+				`:${node.name}(`,
+				renderParametersFragment(state, node),
+				")",
+			),
+		),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+		markClosing(node),
+		state.fragmentLine("end"),
+	);
 }

--- a/src/LuauRenderer/nodes/statements/renderNumericForStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderNumericForStatement.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, markClosing, RenderFragment } from "LuauRenderer/Fragment";
+import { concat, RenderFragment } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
@@ -14,8 +14,8 @@ export function renderNumericForStatement(state: RenderState, node: luau.Numeric
 
 	return concat(
 		state.fragmentLine(concat("for ", renderNode(state, node.id), " = ", predicate, " do")),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-		markClosing(node),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		state.fragmentClosing(node),
 		state.fragmentLine("end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderNumericForStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderNumericForStatement.ts
@@ -15,7 +15,6 @@ export function renderNumericForStatement(state: RenderState, node: luau.Numeric
 	return concat(
 		state.fragmentLine(concat("for ", renderNode(state, node.id), " = ", predicate, " do")),
 		state.block(() => renderStatementsFragment(state, node.statements)),
-		state.fragmentClosing(node),
-		state.fragmentLine("end"),
+		state.fragmentClosingLine(node, "end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderNumericForStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderNumericForStatement.ts
@@ -1,24 +1,21 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, markClosing, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderNumericForStatement(state: RenderState, node: luau.NumericForStatement) {
-	const idStr = render(state, node.id);
-	const startStr = render(state, node.start);
-	const endStr = render(state, node.end);
-
-	let predicateStr = `${startStr}, ${endStr}`;
+	let predicate: RenderFragment = concat(renderNode(state, node.start), ", ", renderNode(state, node.end));
 
 	// step of 1 can be omitted
 	if (node.step && (!luau.isNumberLiteral(node.step) || Number(node.step.value) !== 1)) {
-		const stepStr = render(state, node.step);
-		predicateStr += `, ${stepStr}`;
+		predicate = concat(predicate, ", ", renderNode(state, node.step));
 	}
 
-	let result = "";
-	result += state.line(`for ${idStr} = ${predicateStr} do`);
-	result += state.block(() => renderStatements(state, node.statements));
-	result += state.line(`end`);
-
-	return result;
+	return concat(
+		state.fragmentLine(concat("for ", renderNode(state, node.id), " = ", predicate, " do")),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+		markClosing(node),
+		state.fragmentLine("end"),
+	);
 }

--- a/src/LuauRenderer/nodes/statements/renderRepeatStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderRepeatStatement.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, markClosing } from "LuauRenderer/Fragment";
+import { concat } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
@@ -7,8 +7,8 @@ import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 export function renderRepeatStatement(state: RenderState, node: luau.RepeatStatement) {
 	return concat(
 		state.fragmentLine("repeat"),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-		markClosing(node),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		state.fragmentClosing(node),
 		state.fragmentLine(concat("until ", renderNode(state, node.condition))),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderRepeatStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderRepeatStatement.ts
@@ -1,11 +1,14 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, markClosing } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderRepeatStatement(state: RenderState, node: luau.RepeatStatement) {
-	let result = "";
-	result += state.line(`repeat`);
-	result += state.block(() => renderStatements(state, node.statements));
-	result += state.line(`until ${render(state, node.condition)}`);
-	return result;
+	return concat(
+		state.fragmentLine("repeat"),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+		markClosing(node),
+		state.fragmentLine(concat("until ", renderNode(state, node.condition))),
+	);
 }

--- a/src/LuauRenderer/nodes/statements/renderRepeatStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderRepeatStatement.ts
@@ -8,7 +8,6 @@ export function renderRepeatStatement(state: RenderState, node: luau.RepeatState
 	return concat(
 		state.fragmentLine("repeat"),
 		state.block(() => renderStatementsFragment(state, node.statements)),
-		state.fragmentClosing(node),
-		state.fragmentLine(concat("until ", renderNode(state, node.condition))),
+		state.fragmentClosingLine(node, concat("until ", renderNode(state, node.condition))),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderReturnStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderReturnStatement.ts
@@ -1,9 +1,14 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { concat, join } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderReturnStatement(state: RenderState, node: luau.ReturnStatement) {
-	const expStr = luau.list.isList(node.expression)
-		? luau.list.mapToArray(node.expression, exp => render(state, exp)).join(", ")
-		: render(state, node.expression);
-	return state.line(`return ${expStr}`);
+	const expression = luau.list.isList(node.expression)
+		? join(
+				luau.list.mapToArray(node.expression, item => renderNode(state, item)),
+				", ",
+			)
+		: renderNode(state, node.expression);
+	return state.fragmentLine(concat("return ", expression));
 }

--- a/src/LuauRenderer/nodes/statements/renderVariableDeclaration.ts
+++ b/src/LuauRenderer/nodes/statements/renderVariableDeclaration.ts
@@ -1,26 +1,34 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
-import { render, RenderState } from "LuauRenderer";
+import { concat, join, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 export function renderVariableDeclaration(state: RenderState, node: luau.VariableDeclaration) {
-	let leftStr: string;
+	let left: RenderFragment;
 	if (luau.list.isList(node.left)) {
 		assert(!luau.list.isEmpty(node.left));
-		leftStr = luau.list.mapToArray(node.left, id => render(state, id)).join(", ");
+		left = join(
+			luau.list.mapToArray(node.left, identifier => renderNode(state, identifier)),
+			", ",
+		);
 	} else {
-		leftStr = render(state, node.left);
+		left = renderNode(state, node.left);
 	}
 
 	if (node.right) {
-		let rightStr: string;
+		let right: RenderFragment;
 		if (luau.list.isList(node.right)) {
 			assert(!luau.list.isEmpty(node.right));
-			rightStr = luau.list.mapToArray(node.right, expression => render(state, expression)).join(", ");
+			right = join(
+				luau.list.mapToArray(node.right, expression => renderNode(state, expression)),
+				", ",
+			);
 		} else {
-			rightStr = render(state, node.right);
+			right = renderNode(state, node.right);
 		}
-		return state.line(`local ${leftStr} = ${rightStr}`, node);
+		return state.fragmentLine(concat("local ", left, " = ", right), node);
 	} else {
-		return state.line(`local ${leftStr}`, node);
+		return state.fragmentLine(concat("local ", left), node);
 	}
 }

--- a/src/LuauRenderer/nodes/statements/renderWhileStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderWhileStatement.ts
@@ -1,11 +1,14 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { concat, markClosing } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 
 export function renderWhileStatement(state: RenderState, node: luau.WhileStatement) {
-	let result = "";
-	result += state.line(`while ${render(state, node.condition)} do`);
-	result += state.block(() => renderStatements(state, node.statements));
-	result += state.line(`end`);
-	return result;
+	return concat(
+		state.fragmentLine(concat("while ", renderNode(state, node.condition), " do")),
+		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
+		markClosing(node),
+		state.fragmentLine("end"),
+	);
 }

--- a/src/LuauRenderer/nodes/statements/renderWhileStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderWhileStatement.ts
@@ -8,7 +8,6 @@ export function renderWhileStatement(state: RenderState, node: luau.WhileStateme
 	return concat(
 		state.fragmentLine(concat("while ", renderNode(state, node.condition), " do")),
 		state.block(() => renderStatementsFragment(state, node.statements)),
-		state.fragmentClosing(node),
-		state.fragmentLine("end"),
+		state.fragmentClosingLine(node, "end"),
 	);
 }

--- a/src/LuauRenderer/nodes/statements/renderWhileStatement.ts
+++ b/src/LuauRenderer/nodes/statements/renderWhileStatement.ts
@@ -1,5 +1,5 @@
 import luau from "LuauAST";
-import { concat, markClosing } from "LuauRenderer/Fragment";
+import { concat } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
@@ -7,8 +7,8 @@ import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 export function renderWhileStatement(state: RenderState, node: luau.WhileStatement) {
 	return concat(
 		state.fragmentLine(concat("while ", renderNode(state, node.condition), " do")),
-		state.fragmentBlock(() => renderStatementsFragment(state, node.statements)),
-		markClosing(node),
+		state.block(() => renderStatementsFragment(state, node.statements)),
+		state.fragmentClosing(node),
 		state.fragmentLine("end"),
 	);
 }

--- a/src/LuauRenderer/render.ts
+++ b/src/LuauRenderer/render.ts
@@ -1,6 +1,7 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
 import { getKindName } from "LuauAST/util/getKindName";
+import { flattenFragment, markNode, RenderedNodePosition, RenderFragment } from "LuauRenderer/Fragment";
 import { renderCallExpression } from "LuauRenderer/nodes/expressions/indexable/renderCallExpression";
 import { renderComputedIndexExpression } from "LuauRenderer/nodes/expressions/indexable/renderComputedIndexExpression";
 import { renderIdentifier } from "LuauRenderer/nodes/expressions/indexable/renderIdentifier";
@@ -36,7 +37,6 @@ import { renderRepeatStatement } from "LuauRenderer/nodes/statements/renderRepea
 import { renderReturnStatement } from "LuauRenderer/nodes/statements/renderReturnStatement";
 import { renderVariableDeclaration } from "LuauRenderer/nodes/statements/renderVariableDeclaration";
 import { renderWhileStatement } from "LuauRenderer/nodes/statements/renderWhileStatement";
-import { flattenFragment, markNode, RenderedNodePosition, RenderFragment } from "LuauRenderer/Fragment";
 import { RenderState } from "LuauRenderer/RenderState";
 import { solveTempIds } from "LuauRenderer/solveTempIds";
 import { identity } from "LuauRenderer/util/identity";

--- a/src/LuauRenderer/render.ts
+++ b/src/LuauRenderer/render.ts
@@ -36,13 +36,14 @@ import { renderRepeatStatement } from "LuauRenderer/nodes/statements/renderRepea
 import { renderReturnStatement } from "LuauRenderer/nodes/statements/renderReturnStatement";
 import { renderVariableDeclaration } from "LuauRenderer/nodes/statements/renderVariableDeclaration";
 import { renderWhileStatement } from "LuauRenderer/nodes/statements/renderWhileStatement";
+import { flattenFragment, markNode, RenderedNodePosition, RenderFragment } from "LuauRenderer/Fragment";
 import { RenderState } from "LuauRenderer/RenderState";
 import { solveTempIds } from "LuauRenderer/solveTempIds";
 import { identity } from "LuauRenderer/util/identity";
-import { renderStatements } from "LuauRenderer/util/renderStatements";
+import { renderStatementsFragment } from "LuauRenderer/util/renderStatements";
 import { visit } from "LuauRenderer/util/visit";
 
-type Renderer<T extends luau.SyntaxKind> = (state: RenderState, node: luau.NodeByKind[T]) => string;
+type Renderer<T extends luau.SyntaxKind> = (state: RenderState, node: luau.NodeByKind[T]) => RenderFragment;
 
 const KIND_TO_RENDERER = identity<{ [K in luau.SyntaxKind]: Renderer<K> }>({
 	// indexable expressions
@@ -101,8 +102,13 @@ const KIND_TO_RENDERER = identity<{ [K in luau.SyntaxKind]: Renderer<K> }>({
  * @param node The node to render as Luau code.
  */
 export function render<T extends luau.SyntaxKind>(state: RenderState, node: luau.Node<T>): string {
+	return flattenFragment(renderNode(state, node)).code;
+}
+
+/** @internal */
+export function renderNode<T extends luau.SyntaxKind>(state: RenderState, node: luau.Node<T>): RenderFragment {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	return KIND_TO_RENDERER[node.kind](state, node as any);
+	return markNode(node, KIND_TO_RENDERER[node.kind](state, node as any));
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -134,5 +140,20 @@ export function renderAST(ast: luau.List<luau.Statement>): string {
 	// useful for visualizing the Luau AST structure
 	// debugAST(ast);
 
-	return renderStatements(state, ast);
+	return flattenFragment(renderStatementsFragment(state, ast)).code;
+}
+
+export interface RenderResultWithPositions {
+	code: string;
+	positions: ReadonlyArray<RenderedNodePosition>;
+}
+
+/**
+ * Renders a syntax tree and reports the exact generated range of each emitted node.
+ * Positions are zero-based UTF-16 line and column offsets.
+ */
+export function renderASTWithPositions(ast: luau.List<luau.Statement>): RenderResultWithPositions {
+	const state = new RenderState();
+	solveTempIds(state, ast);
+	return flattenFragment(renderStatementsFragment(state, ast), true);
 }

--- a/src/LuauRenderer/render.ts
+++ b/src/LuauRenderer/render.ts
@@ -108,7 +108,8 @@ export function render<T extends luau.SyntaxKind>(state: RenderState, node: luau
 /** @internal */
 export function renderNode<T extends luau.SyntaxKind>(state: RenderState, node: luau.Node<T>): RenderFragment {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	return markNode(node, KIND_TO_RENDERER[node.kind](state, node as any));
+	const content = KIND_TO_RENDERER[node.kind](state, node as any);
+	return state.includePositions ? markNode(node, content) : content;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -153,7 +154,7 @@ export interface RenderResultWithPositions {
  * Positions are zero-based UTF-16 line and column offsets.
  */
 export function renderASTWithPositions(ast: luau.List<luau.Statement>): RenderResultWithPositions {
-	const state = new RenderState();
+	const state = new RenderState(true);
 	solveTempIds(state, ast);
 	return flattenFragment(renderStatementsFragment(state, ast), true);
 }

--- a/src/LuauRenderer/util/renderArguments.ts
+++ b/src/LuauRenderer/util/renderArguments.ts
@@ -1,7 +1,17 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { flattenFragment, join, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 /** Renders the given list of expressions into a string separated by commas */
 export function renderArguments(state: RenderState, expressions: luau.List<luau.Expression>) {
-	return luau.list.mapToArray(expressions, v => render(state, v)).join(", ");
+	return flattenFragment(renderArgumentsFragment(state, expressions)).code;
+}
+
+/** @internal */
+export function renderArgumentsFragment(state: RenderState, expressions: luau.List<luau.Expression>): RenderFragment {
+	return join(
+		luau.list.mapToArray(expressions, expression => renderNode(state, expression)),
+		", ",
+	);
 }

--- a/src/LuauRenderer/util/renderParameters.ts
+++ b/src/LuauRenderer/util/renderParameters.ts
@@ -1,5 +1,7 @@
 import luau from "LuauAST";
-import { render, RenderState } from "LuauRenderer";
+import { flattenFragment, join, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 /**
  * Renders the given list of identifiers inside of `node` into a string sepearted by commas
@@ -7,9 +9,14 @@ import { render, RenderState } from "LuauRenderer";
  * Adds `...` onto the end if node.hasDotDotDot is true
  */
 export function renderParameters(state: RenderState, node: luau.HasParameters) {
-	const paramStrs = luau.list.mapToArray(node.parameters, param => render(state, param));
+	return flattenFragment(renderParametersFragment(state, node)).code;
+}
+
+/** @internal */
+export function renderParametersFragment(state: RenderState, node: luau.HasParameters): RenderFragment {
+	const parameters = luau.list.mapToArray(node.parameters, parameter => renderNode(state, parameter));
 	if (node.hasDotDotDot) {
-		paramStrs.push("...");
+		parameters.push("...");
 	}
-	return paramStrs.join(", ");
+	return join(parameters, ", ");
 }

--- a/src/LuauRenderer/util/renderStatements.ts
+++ b/src/LuauRenderer/util/renderStatements.ts
@@ -1,6 +1,6 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
-import { concat, flattenFragment, RenderFragment } from "LuauRenderer/Fragment";
+import { flattenFragment, RenderFragment, sequence } from "LuauRenderer/Fragment";
 import { renderNode } from "LuauRenderer/render";
 import { RenderState } from "LuauRenderer/RenderState";
 
@@ -17,7 +17,7 @@ export function renderStatements(state: RenderState, statements: luau.List<luau.
 
 /** @internal */
 export function renderStatementsFragment(state: RenderState, statements: luau.List<luau.Statement>): RenderFragment {
-	const result = new Array<RenderFragment>();
+	let result: string | Array<RenderFragment> = state.includePositions ? new Array<RenderFragment>() : "";
 	let listNode = statements.head;
 	let hasFinalStatement = false;
 	while (listNode !== undefined) {
@@ -28,10 +28,15 @@ export function renderStatementsFragment(state: RenderState, statements: luau.Li
 		hasFinalStatement ||= luau.isFinalStatement(listNode.value);
 
 		state.pushListNode(listNode);
-		result.push(renderNode(state, listNode.value));
+		const statement = renderNode(state, listNode.value);
+		if (typeof result === "string") {
+			result += statement as string;
+		} else {
+			result.push(statement);
+		}
 		state.popListNode();
 
 		listNode = listNode.next;
 	}
-	return concat(...result);
+	return typeof result === "string" ? result : sequence(result);
 }

--- a/src/LuauRenderer/util/renderStatements.ts
+++ b/src/LuauRenderer/util/renderStatements.ts
@@ -1,6 +1,8 @@
 import luau from "LuauAST";
 import { assert } from "LuauAST/util/assert";
-import { render, RenderState } from "LuauRenderer";
+import { concat, flattenFragment, RenderFragment } from "LuauRenderer/Fragment";
+import { renderNode } from "LuauRenderer/render";
+import { RenderState } from "LuauRenderer/RenderState";
 
 /**
  * Renders the given list of statements.
@@ -10,7 +12,12 @@ import { render, RenderState } from "LuauRenderer";
  * Useful for getting the next or previous sibling statement.
  */
 export function renderStatements(state: RenderState, statements: luau.List<luau.Statement>) {
-	let result = "";
+	return flattenFragment(renderStatementsFragment(state, statements)).code;
+}
+
+/** @internal */
+export function renderStatementsFragment(state: RenderState, statements: luau.List<luau.Statement>): RenderFragment {
+	const result = new Array<RenderFragment>();
 	let listNode = statements.head;
 	let hasFinalStatement = false;
 	while (listNode !== undefined) {
@@ -21,10 +28,10 @@ export function renderStatements(state: RenderState, statements: luau.List<luau.
 		hasFinalStatement ||= luau.isFinalStatement(listNode.value);
 
 		state.pushListNode(listNode);
-		result += render(state, listNode.value);
+		result.push(renderNode(state, listNode.value));
 		state.popListNode();
 
 		listNode = listNode.next;
 	}
-	return result;
+	return concat(...result);
 }

--- a/tests/origin.test.js
+++ b/tests/origin.test.js
@@ -7,7 +7,7 @@ const luau = luauModule.default;
 test("node origins survive the package's shallow clone paths", () => {
 	const origin = {
 		start: { line: 4, column: 2 },
-		end: { line: 4, column: 7 },
+		closing: { line: 4, column: 7 },
 	};
 	const identifier = luauModule.setNodeOrigin(luau.id("value"), origin);
 	luau.create(luau.SyntaxKind.VariableDeclaration, { left: identifier, right: undefined });

--- a/tests/origin.test.js
+++ b/tests/origin.test.js
@@ -1,0 +1,26 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const luauModule = require("../out/LuauAST");
+const luau = luauModule.default;
+
+test("node origins survive the package's shallow clone paths", () => {
+	const origin = {
+		start: { line: 4, column: 2 },
+		end: { line: 4, column: 7 },
+	};
+	const identifier = luauModule.setNodeOrigin(luau.id("value"), origin);
+	luau.create(luau.SyntaxKind.VariableDeclaration, { left: identifier, right: undefined });
+	const declarationWithClone = luau.create(luau.SyntaxKind.VariableDeclaration, {
+		left: identifier,
+		right: undefined,
+	});
+
+	assert.notEqual(declarationWithClone.left, identifier);
+	assert.equal(declarationWithClone.left.origin, origin);
+
+	const statement = luauModule.setNodeOrigin(luau.comment(" origin"), origin);
+	const clonedList = luau.list.clone(luau.list.make(statement));
+	assert.notEqual(clonedList.head.value, statement);
+	assert.equal(clonedList.head.value.origin, origin);
+});

--- a/tests/renderPositions.test.js
+++ b/tests/renderPositions.test.js
@@ -1,0 +1,55 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const luauModule = require("../out/LuauAST");
+const luau = luauModule.default;
+
+test("reports generated ranges from the emitted layout", () => {
+	const printStatement = luau.create(luau.SyntaxKind.CallStatement, {
+		expression: luau.call(luau.id("print"), [luau.string("inside")]),
+	});
+	const callback = luau.create(luau.SyntaxKind.FunctionExpression, {
+		statements: luau.list.make(printStatement),
+		parameters: luau.list.make(),
+		hasDotDotDot: false,
+	});
+	const declaration = luau.create(luau.SyntaxKind.VariableDeclaration, {
+		left: luau.id("callback"),
+		right: callback,
+	});
+	const ast = luau.list.make(declaration);
+
+	const rendered = luauModule.renderASTWithPositions(ast);
+
+	assert.equal(rendered.code, "local callback = function()\n\tprint(\"inside\")\nend\n");
+	assert.equal(rendered.code, luauModule.renderAST(ast));
+	const rangeOf = node => rendered.positions.find(position => position.node === node).range;
+	assert.deepEqual(rangeOf(declaration), {
+		start: { line: 0, column: 0 },
+		end: { line: 3, column: 0 },
+	});
+	assert.deepEqual(rangeOf(callback), {
+		start: { line: 0, column: 17 },
+		end: { line: 2, column: 3 },
+		closing: { line: 2, column: 0 },
+	});
+	assert.deepEqual(rangeOf(printStatement), {
+		start: { line: 1, column: 0 },
+		end: { line: 2, column: 0 },
+	});
+});
+
+test("reports every occurrence when a node identity is rendered twice", () => {
+	const statement = luau.comment(" same node");
+	const rendered = luauModule.renderASTWithPositions(luau.list.make(statement, statement));
+	const occurrences = rendered.positions.filter(position => position.node === statement);
+
+	assert.equal(rendered.code, "-- same node\n-- same node\n");
+	assert.deepEqual(
+		occurrences.map(occurrence => occurrence.range),
+		[
+			{ start: { line: 0, column: 0 }, end: { line: 1, column: 0 } },
+			{ start: { line: 1, column: 0 }, end: { line: 2, column: 0 } },
+		],
+	);
+});

--- a/tests/renderPositions.test.js
+++ b/tests/renderPositions.test.js
@@ -53,3 +53,106 @@ test("reports every occurrence when a node identity is rendered twice", () => {
 		],
 	);
 });
+
+test("uses UTF-16 columns and treats CRLF as one generated line break", () => {
+	const value = luau.string("😀\r\nnext\"'");
+	const declaration = luau.create(luau.SyntaxKind.VariableDeclaration, {
+		left: luau.id("value"),
+		right: value,
+	});
+	const rendered = luauModule.renderASTWithPositions(luau.list.make(declaration));
+	const valueRange = rendered.positions.find(position => position.node === value).range;
+
+	assert.equal(rendered.code, "local value = [[😀\r\nnext\"']]\n");
+	assert.deepEqual(valueRange, {
+		start: { line: 0, column: 14 },
+		end: { line: 1, column: 8 },
+	});
+});
+
+test("reports empty function closings and empty table ranges", () => {
+	const callback = luau.create(luau.SyntaxKind.FunctionExpression, {
+		statements: luau.list.make(),
+		parameters: luau.list.make(),
+		hasDotDotDot: false,
+	});
+	const table = luau.map();
+	const rendered = luauModule.renderASTWithPositions(
+		luau.list.make(
+			luau.create(luau.SyntaxKind.VariableDeclaration, {
+				left: luau.id("emptyFunction"),
+				right: callback,
+			}),
+			luau.create(luau.SyntaxKind.VariableDeclaration, {
+				left: luau.id("emptyMap"),
+				right: table,
+			}),
+		),
+	);
+	const rangeOf = node => rendered.positions.find(position => position.node === node).range;
+
+	assert.equal(rendered.code, "local emptyFunction = function() end\nlocal emptyMap = {}\n");
+	assert.deepEqual(rangeOf(callback), {
+		start: { line: 0, column: 22 },
+		end: { line: 0, column: 36 },
+		closing: { line: 0, column: 33 },
+	});
+	assert.deepEqual(rangeOf(table), {
+		start: { line: 1, column: 17 },
+		end: { line: 1, column: 19 },
+	});
+});
+
+test("gives elseif occurrences their own range and the outer if its shared closing", () => {
+	const elseifNode = luau.create(luau.SyntaxKind.IfStatement, {
+		condition: luau.bool(false),
+		statements: luau.list.make(luau.comment(" elseif")),
+		elseBody: luau.list.make(),
+	});
+	const ifNode = luau.create(luau.SyntaxKind.IfStatement, {
+		condition: luau.bool(true),
+		statements: luau.list.make(luau.comment(" then")),
+		elseBody: elseifNode,
+	});
+	const rendered = luauModule.renderASTWithPositions(luau.list.make(ifNode));
+	const rangeOf = node => rendered.positions.find(position => position.node === node).range;
+
+	assert.equal(rendered.code, "if true then\n\t-- then\nelseif false then\n\t-- elseif\nend\n");
+	assert.deepEqual(rangeOf(elseifNode), {
+		start: { line: 2, column: 0 },
+		end: { line: 4, column: 0 },
+	});
+	assert.deepEqual(rangeOf(ifNode), {
+		start: { line: 0, column: 0 },
+		end: { line: 5, column: 0 },
+		closing: { line: 4, column: 0 },
+	});
+});
+
+test("keeps renderAST assertion behavior when positions are requested", () => {
+	const ast = luau.list.make(
+		luau.create(luau.SyntaxKind.ReturnStatement, { expression: luau.number(1) }),
+		luau.create(luau.SyntaxKind.CallStatement, { expression: luau.call(luau.id("unreachable")) }),
+	);
+
+	assert.throws(() => luauModule.renderAST(ast), /Cannot render statement after break, continue, or return!/);
+	assert.throws(
+		() => luauModule.renderASTWithPositions(ast),
+		/Cannot render statement after break, continue, or return!/,
+	);
+});
+
+test("handles a large flat AST without exhausting the stack", () => {
+	const statements = Array.from({ length: 10_000 }, (_, index) => luau.comment(` line ${index}`));
+	const ast = luau.list.make(...statements);
+
+	const plain = luauModule.renderAST(ast);
+	const positioned = luauModule.renderASTWithPositions(ast);
+
+	assert.equal(positioned.code, plain);
+	assert.equal(positioned.positions.length, statements.length);
+	assert.deepEqual(positioned.positions.at(-1).range, {
+		start: { line: 9_999, column: 0 },
+		end: { line: 10_000, column: 0 },
+	});
+});

--- a/tests/renderPositions.test.js
+++ b/tests/renderPositions.test.js
@@ -103,6 +103,58 @@ test("reports empty function closings and empty table ranges", () => {
 	});
 });
 
+test("reports closing keywords after indentation in nested blocks", () => {
+	const innerDo = luau.create(luau.SyntaxKind.DoStatement, {
+		statements: luau.list.make(luau.comment(" do body")),
+	});
+	const whileStatement = luau.create(luau.SyntaxKind.WhileStatement, {
+		condition: luau.bool(true),
+		statements: luau.list.make(luau.comment(" while body")),
+	});
+	const functionDeclaration = luau.create(luau.SyntaxKind.FunctionDeclaration, {
+		localize: true,
+		name: luau.id("declared"),
+		parameters: luau.list.make(),
+		hasDotDotDot: false,
+		statements: luau.list.make(luau.comment(" function body")),
+	});
+	const repeatStatement = luau.create(luau.SyntaxKind.RepeatStatement, {
+		condition: luau.bool(true),
+		statements: luau.list.make(luau.comment(" repeat body")),
+	});
+	const functionExpression = luau.create(luau.SyntaxKind.FunctionExpression, {
+		parameters: luau.list.make(),
+		hasDotDotDot: false,
+		statements: luau.list.make(luau.comment(" callback body")),
+	});
+	const outerDo = luau.create(luau.SyntaxKind.DoStatement, {
+		statements: luau.list.make(
+			innerDo,
+			whileStatement,
+			functionDeclaration,
+			repeatStatement,
+			luau.create(luau.SyntaxKind.VariableDeclaration, {
+				left: luau.id("callback"),
+				right: functionExpression,
+			}),
+		),
+	});
+
+	const rendered = luauModule.renderASTWithPositions(luau.list.make(outerDo));
+	const closingOf = node => rendered.positions.find(position => position.node === node).range.closing;
+
+	assert.equal(
+		rendered.code,
+		"do\n\tdo\n\t\t-- do body\n\tend\n\twhile true do\n\t\t-- while body\n\tend\n\tlocal function declared()\n\t\t-- function body\n\tend\n\trepeat\n\t\t-- repeat body\n\tuntil true\n\tlocal callback = function()\n\t\t-- callback body\n\tend\nend\n",
+	);
+	assert.deepEqual(closingOf(innerDo), { line: 3, column: 1 });
+	assert.deepEqual(closingOf(whileStatement), { line: 6, column: 1 });
+	assert.deepEqual(closingOf(functionDeclaration), { line: 9, column: 1 });
+	assert.deepEqual(closingOf(repeatStatement), { line: 12, column: 1 });
+	assert.deepEqual(closingOf(functionExpression), { line: 15, column: 1 });
+	assert.deepEqual(closingOf(outerDo), { line: 16, column: 0 });
+});
+
 test("gives elseif occurrences their own range and the outer if its shared closing", () => {
 	const elseifNode = luau.create(luau.SyntaxKind.IfStatement, {
 		condition: luau.bool(false),

--- a/tests/renderPositions.test.js
+++ b/tests/renderPositions.test.js
@@ -156,3 +156,78 @@ test("handles a large flat AST without exhausting the stack", () => {
 		end: { line: 10_000, column: 0 },
 	});
 });
+
+test("tracks multiline comments containing Unicode and CRLF", () => {
+	const comment = luau.comment("😀\r\nline");
+	const rendered = luauModule.renderASTWithPositions(luau.list.make(comment));
+	const occurrence = rendered.positions.find(position => position.node === comment);
+
+	assert.equal(rendered.code, "--[[\n\t😀\r\n\tline\n]]\n");
+	assert.deepEqual(occurrence.range, {
+		start: { line: 0, column: 0 },
+		end: { line: 4, column: 0 },
+	});
+});
+
+test("distinguishes adjacent identical function expressions by identity", () => {
+	const createEmptyFunction = () =>
+		luau.create(luau.SyntaxKind.FunctionExpression, {
+			statements: luau.list.make(),
+			parameters: luau.list.make(),
+			hasDotDotDot: false,
+		});
+	const first = createEmptyFunction();
+	const second = createEmptyFunction();
+	const rendered = luauModule.renderASTWithPositions(
+		luau.list.make(
+			luau.create(luau.SyntaxKind.VariableDeclaration, { left: luau.id("f1"), right: first }),
+			luau.create(luau.SyntaxKind.VariableDeclaration, { left: luau.id("f2"), right: second }),
+		),
+	);
+	const functionOccurrences = rendered.positions.filter(position => position.node === first || position.node === second);
+
+	assert.equal(rendered.code, "local f1 = function() end\nlocal f2 = function() end\n");
+	assert.deepEqual(
+		functionOccurrences.map(position => ({ node: position.node, range: position.range })),
+		[
+			{
+				node: first,
+				range: {
+					start: { line: 0, column: 11 },
+					end: { line: 0, column: 25 },
+					closing: { line: 0, column: 22 },
+				},
+			},
+			{
+				node: second,
+				range: {
+					start: { line: 1, column: 11 },
+					end: { line: 1, column: 25 },
+					closing: { line: 1, column: 22 },
+				},
+			},
+		],
+	);
+});
+
+test("renders a wide elseif expression without recursive fragment flattening", () => {
+	const alternativeCount = 10_000;
+	let alternative = luau.nil();
+	for (let index = alternativeCount - 1; index >= 0; index--) {
+		alternative = luau.create(luau.SyntaxKind.IfExpression, {
+			condition: luau.bool(false),
+			expression: luau.number(index),
+			alternative,
+		});
+	}
+	const expression = luau.create(luau.SyntaxKind.IfExpression, {
+		condition: luau.bool(true),
+		expression: luau.number(0),
+		alternative,
+	});
+
+	const code = luauModule.render(new luauModule.RenderState(), expression);
+	assert.equal(code.match(/elseif/g).length, alternativeCount);
+	assert.ok(code.startsWith("if true then 0 elseif false then 0 "));
+	assert.ok(code.endsWith("else nil"));
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"module": "commonjs",
 		"target": "ES2019",
 		"lib": ["ES2019"],
+		"types": ["node"],
 		"strict": true,
 		"noFallthroughCasesInSwitch": true,
 		"strictNullChecks": true,


### PR DESCRIPTION
Source-map consumers need positions tied to the text the Luau renderer emits. This adds `renderASTWithPositions()`, returning the same Luau text plus ordered node occurrences with generated start, exclusive end, and closing-keyword positions. The string and position APIs share one formatting implementation; positions are collected while flattening the renderer's output, without re-rendering subtrees or reconstructing their layout elsewhere.

Optional, language-neutral `NodeOrigin` metadata preserves source anchors across AST clones. Repeated node identities retain separate generated occurrences. Public rendering tests cover nested expressions and blocks, closing columns, Unicode/CRLF, multiline content, wide trees, cloning, and existing final-statement assertions. The existing string-returning entry points remain available.

This is the renderer prerequisite for roblox-ts/roblox-ts#3060. A `prepare` build makes the dependent draft's exact Git pin installable; normal registry consumers receive the compiled package.

Performance tradeoff: on a local synthetic 88 KB AST (600 statement groups and depth 48), 100 warmed samples measured a median of about 2.42 ms for string-only rendering versus 1.64 ms with 2.1.0, and 3.26 ms with positions. Emitted text is identical. These are renderer measurements, not end-to-end compiler timings.

Validation: all hosted Build, ESLint, and Unit Tests checks pass. The compatibility job also builds and tests upstream roblox-ts with this renderer. Independent local Standards and Spec reviews found no blocking findings.

Generated with Codex.

