### PR TITLE
Render blank comment lines without indentation

### DIFF
--- a/src/LuauRenderer/nodes/statements/renderComment.ts
+++ b/src/LuauRenderer/nodes/statements/renderComment.ts
@@ -7,7 +7,10 @@ export function renderComment(state: RenderState, node: luau.Comment) {
 	if (lines.length > 1) {
 		const eqStr = getSafeBracketEquals(node.text);
 		let result = state.line(`--[${eqStr}[`);
-		result += state.block(() => lines.map(line => state.line(line)).join(""));
+		// indenting a blank line would only add trailing whitespace
+		result += state.block(() =>
+			lines.map(line => (line.trim() === "" ? state.newline("") : state.line(line))).join(""),
+		);
 		result += state.line(`]${eqStr}]`);
 		return result;
 	} else {


### PR DESCRIPTION
Multi-line comments indent every line inside `--[[ ]]`, including blank ones. A blank line therefore renders as the current indentation alone, leaving trailing whitespace in the output. Lines containing only whitespace now render as empty lines.

```lua
local function run()
	--[[
		first paragraph

		second paragraph
	]]
end
```

The blank line above previously contained two tabs; it is now empty.

This is the renderer prerequisite for [roblox-ts/roblox-ts#3070](https://github.com/roblox-ts/roblox-ts/pull/3070), which removes JSDoc gutters, delimiter lines, and source indentation from emitted comments.

Validation:

- `npm run build` and `npm run eslint` in luau-ast
- `npm test` in roblox-ts master with this renderer installed: 614 compiler tests, 121 snapshots, and 767 runtime tests passed
- `git diff --check`
